### PR TITLE
Flink init action: Set HADOOP_PATH env var to start the yarn session.

### DIFF
--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -162,7 +162,7 @@ EOF
 #!/bin/bash
 set -exuo pipefail
 sudo -u yarn -i \
-HADOOP_CLASSPATH=`hadoop classpath` \
+HADOOP_CLASSPATH=$(hadoop classpath) \
 HADOOP_CONF_DIR=${HADOOP_CONF_DIR} \
   ${FLINK_INSTALL_DIR}/bin/yarn-session.sh \
   -n "${num_taskmanagers}" \

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -162,6 +162,7 @@ EOF
 #!/bin/bash
 set -exuo pipefail
 sudo -u yarn -i \
+HADOOP_CLASSPATH=`hadoop classpath` \
 HADOOP_CONF_DIR=${HADOOP_CONF_DIR} \
   ${FLINK_INSTALL_DIR}/bin/yarn-session.sh \
   -n "${num_taskmanagers}" \


### PR DESCRIPTION
Without this, an exception is raised:
>java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configuration
