### PR TITLE
To fix socket.gaierror

### DIFF
--- a/jupyter2/jupyter2.sh
+++ b/jupyter2/jupyter2.sh
@@ -51,7 +51,7 @@ function configure_jupyter() {
 ## Configs generated in Dataproc init action
 c.Application.log_level = 'DEBUG'
 c.JupyterApp.answer_yes = True
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.allow_root= True
 c.NotebookApp.open_browser = False
 c.NotebookApp.port = ${JUPYTER_PORT}


### PR DESCRIPTION
Jupyter component is throwing socket.gaierror 

```
File "/opt/conda/anaconda/lib/python2.7/site-packages/notebook/notebookapp.py", line 867, in _default_allow_remote
    for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
socket.gaierror: [Errno -2] Name or service not known
```