### PR TITLE
Remove deprecation notice

### DIFF
--- a/starburst-presto/README.md
+++ b/starburst-presto/README.md
@@ -1,15 +1,3 @@
---------------------------------------------------------------------------------
-
-# NOTE: *The Presto initialization action has been deprecated. Please use the Presto Component*
-
-**The
-[Presto Component](https://cloud.google.com/dataproc/docs/concepts/components/presto)
-is the best way to use Presto with Cloud Dataproc. To learn more about Dataproc
-Components see
-[here](https://cloud.google.com/dataproc/docs/concepts/components/overview).**
-
---------------------------------------------------------------------------------
-
 # Presto
 
 This initialization action installs


### PR DESCRIPTION
Reason: Starburst Presto distribution is not used in Presto Component.