### PR TITLE
Updating presto to v332

### DIFF
--- a/starburst-presto/presto.sh
+++ b/starburst-presto/presto.sh
@@ -36,26 +36,6 @@ function err() {
   return 1
 }
 
-function retry_apt_command() {
-  cmd="$1"
-  for ((i = 0; i < 10; i++)); do
-    if eval "$cmd"; then
-      return 0
-    fi
-    sleep 5
-  done
-  return 1
-}
-
-function update_apt_get() {
-  retry_apt_command "apt-get update"
-}
-
-function install_apt_get() {
-  local pkgs="$*"
-  retry_apt_command "apt-get install -y $pkgs"
-}
-
 function wait_for_presto_cluster_ready() {
   # wait up to 120s for presto being able to run query
   for ((i = 0; i < 12; i++)); do
@@ -180,6 +160,7 @@ function configure_jvm() {
 -Djdk.nio.maxCachedBufferSize=2000000
 -Dhive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 -Djava.library.path=/usr/lib/hadoop/lib/native/:/usr/lib/
+-Dpresto-temporarily-allow-java8=true
 EOF
 }
 
@@ -248,9 +229,6 @@ EOF
 # Configure Presto
 function configure_and_start_presto() {
   mkdir -p /opt/presto-server/etc/catalog
-
-  update_apt_get
-  install_apt_get openjdk-11-jre
 
   configure_node_properties
   configure_hive

--- a/starburst-presto/presto.sh
+++ b/starburst-presto/presto.sh
@@ -22,8 +22,8 @@ readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly PRESTO_MASTER_FQDN="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
 readonly WORKER_COUNT=$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)
 readonly PRESTO_BASE_URL=https://storage.googleapis.com/starburstdata/presto
-readonly PRESTO_MAJOR_VERSION="323"
-readonly PRESTO_VERSION="${PRESTO_MAJOR_VERSION}-e.3"
+readonly PRESTO_MAJOR_VERSION="332"
+readonly PRESTO_VERSION="${PRESTO_MAJOR_VERSION}-e.0"
 readonly HTTP_PORT="$(/usr/share/google/get_metadata_value attributes/presto-port || echo 8080)"
 readonly INIT_SCRIPT="/usr/lib/systemd/system/presto.service"
 PRESTO_JVM_MB=0
@@ -34,6 +34,26 @@ PRESTO_HEADROOM_NODE_MB=256
 function err() {
   echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
   return 1
+}
+
+function retry_apt_command() {
+  cmd="$1"
+  for ((i = 0; i < 10; i++)); do
+    if eval "$cmd"; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+function update_apt_get() {
+  retry_apt_command "apt-get update"
+}
+
+function install_apt_get() {
+  local pkgs="$*"
+  retry_apt_command "apt-get install -y $pkgs"
 }
 
 function wait_for_presto_cluster_ready() {
@@ -228,6 +248,9 @@ EOF
 # Configure Presto
 function configure_and_start_presto() {
   mkdir -p /opt/presto-server/etc/catalog
+
+  update_apt_get
+  install_apt_get openjdk-11-jre
 
   configure_node_properties
   configure_hive


### PR DESCRIPTION

NOTE: If we don't use Java 11
Then we get the following error:

```bash
INFO	main	stderr	ERROR: Future versions of Presto will require Java 11 after March 2020.

You may temporarily continue running on Java 8 by adding the following
JVM config option:

    -Dpresto-temporarily-allow-java8=true
```