### PR TITLE
[cloud-sql-proxy] Execute the Hive "reload function" DDL

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -329,6 +329,11 @@ function configure_hive_warehouse_dir() {
   echo "Updated hive warehouse dir"
 }
 
+function reload_function() {
+  beeline -u "$(get_hiveserver_uri)" -e "reload function;"
+  echo "Reloaded permanent functions"
+}
+
 function main() {
   local role
   role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
@@ -390,6 +395,9 @@ function main() {
         # Set hive.metastore.warehouse.dir only on other masters.
         configure_hive_warehouse_dir
       fi
+      # Execute the Hive "reload function" DDL to reflect permanent functions
+      # that have already been created in the HiveServer.
+      reload_function
     fi
   else
     # This part runs on workers.


### PR DESCRIPTION
## Issue
HiveServer, which runs on an ephemeral cluster and connects to an external Cloud SQL [[official doc](https://cloud.google.com/solutions/using-apache-hive-on-cloud-dataproc)], cannot resolve permanent Hive UDFs that have already been created unless users explicitly execute the Hive `reload function` due to [the limiation of Hive UDFs ](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/ReloadFunction).

## Solution
Make the cloud-sql-proxy initialization script to execute the Hive `reload function` so that HiveServer on an ephemeral cluster can resolve permanent Hive UDFs automatically while its creation.