### PR TITLE
give yarn service account permission to gpu device

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -265,6 +265,10 @@ function main() {
   chmod g+rwx -R /sys/fs/cgroup/cpu,cpuacct
   chown :yarn -R /sys/fs/cgroup/devices
   chmod g+rwx -R /sys/fs/cgroup/devices
+  chown yarn:yarn -R /hadoop/yarn
+  chmod g+rwx -R /hadoop/yarn
+  sed -i "s/yarn.nodemanager\.linux\-container\-executor\.group\=/yarn\.nodemanager\.linux\-container\-executor\.group\=yarn\n\n\[gpu\]\nmodule\.enable\=true\n\[cgroups\]\nroot\=\/sys\/fs\/cgroup\nyarn\-hierachy\=yarn\n/g" /etc/hadoop/conf/container-executor.cfg
+
 }
 
 main

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -258,6 +258,11 @@ function main() {
   else
     echo 'GPU metrics will not be installed.'
   fi
+  
+  chown :yarn -R /sys/fs/cgroup/cpu,cpuacct
+  chmod g+rwx -R /sys/fs/cgroup/cpu,cpuacct
+  chown :yarn -R /sys/fs/cgroup/devices
+  chmod g+rwx -R /sys/fs/cgroup/devices
 }
 
 main

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -82,7 +82,6 @@ function install_nvidia_nccl() {
   execute_with_retries \
     "apt-get install -y --allow-unauthenticated libnccl2=${nccl_version} libnccl-dev=${nccl_version}"
 
-  nvidia-smi -c EXCLUSIVE_PROCESS
 }
 
 # Install NVIDIA GPU driver provided by NVIDIA
@@ -250,7 +249,10 @@ function main() {
     echo "Unsupported GPU driver provider: '${GPU_DRIVER_PROVIDER}'"
     exit 1
   fi
-
+  
+  # include exclusive mode on GPU
+  nvidia-smi -c EXCLUSIVE_PROCESS
+  
   # Install GPU metrics collection in Stackdriver if needed
   if [[ ${INSTALL_GPU_AGENT} == true ]]; then
     install_gpu_agent


### PR DESCRIPTION
seems like 
chown :yarn -R /sys/fs/cgroup/cpu,cpuacct
chmod g+rwx -R /sys/fs/cgroup/cpu,cpuacct
chown :yarn -R /sys/fs/cgroup/devices
chmod g+rwx -R /sys/fs/cgroup/devices
is required to make gpu resource available to yarn.