### PR TITLE
Switch integration tests to E2 VMs and reduce parallelism

### DIFF
--- a/alluxio/test_alluxio.py
+++ b/alluxio/test_alluxio.py
@@ -20,7 +20,7 @@ class AlluxioTestCase(DataprocTestCase):
             configuration,
             self.INIT_ACTIONS,
             metadata=self.METADATA,
-            machine_type="n1-standard-4")
+            machine_type="e2-standard-4")
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),
                                                 machine_suffix))
@@ -33,7 +33,7 @@ class AlluxioTestCase(DataprocTestCase):
             configuration,
             init_actions,
             metadata=self.METADATA,
-            machine_type="n1-standard-4")
+            machine_type="e2-standard-4")
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),
                                                 machine_suffix))

--- a/atlas/test_atlas.py
+++ b/atlas/test_atlas.py
@@ -108,14 +108,14 @@ class AtlasTestCase(DataprocTestCase):
                                        metadata=metadata,
                                        timeout_in_minutes=30,
                                        optional_components=optional_components,
-                                       machine_type="n1-standard-4")
+                                       machine_type="e2-standard-4")
         else:
             self.createCluster(configuration,
                                init_actions,
                                beta=True,
                                timeout_in_minutes=30,
                                optional_components=optional_components,
-                               machine_type="n1-standard-4")
+                               machine_type="e2-standard-4")
 
         atlas_statuses = []
         for machine_suffix in machine_suffixes:
@@ -156,7 +156,7 @@ class AtlasTestCase(DataprocTestCase):
                            timeout_in_minutes=30,
                            metadata=metadata,
                            optional_components=self.OPTIONAL_COMPONENTS,
-                           machine_type="n1-standard-4")
+                           machine_type="e2-standard-4")
         for machine_suffix in machine_suffixes:
             self.verify_instance(
                 "{}-{}".format(self.getClusterName(), machine_suffix),
@@ -173,7 +173,7 @@ class AtlasTestCase(DataprocTestCase):
                 self.INIT_ACTIONS,
                 beta=True,
                 timeout_in_minutes=30,
-                machine_type="n1-standard-4",
+                machine_type="e2-standard-4",
                 optional_components=self.OPTIONAL_COMPONENTS.remove(component))
 
     def test_atlas_ha_fails_without_kafka(self):
@@ -185,7 +185,7 @@ class AtlasTestCase(DataprocTestCase):
                                self.INIT_ACTIONS,
                                timeout_in_minutes=30,
                                beta=True,
-                               machine_type="n1-standard-4",
+                               machine_type="e2-standard-4",
                                optional_components=self.OPTIONAL_COMPONENTS_HA)
 
 

--- a/cloud-sql-proxy/test_cloud_sql_proxy.py
+++ b/cloud-sql-proxy/test_cloud_sql_proxy.py
@@ -61,7 +61,6 @@ class CloudSqlProxyTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             metadata=metadata,
             scopes='sql-admin')
 

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -85,12 +85,13 @@ determine_tests_to_run() {
 }
 
 run_tests() {
+  local -r max_parallel_tests=10
   bazel test \
-    --jobs=15 \
-    --local_cpu_resources=15 \
-    --local_ram_resources=$((15 * 1024)) \
-    --action_env=INTERNAL_IP_SSH=true \
-    --test_output=errors \
+    --jobs="${max_parallel_tests}" \
+    --local_cpu_resources="${max_parallel_tests}" \
+    --local_ram_resources="$((max_parallel_tests * 1024))" \
+    --action_env="INTERNAL_IP_SSH=true" \
+    --test_output="errors" \
     --noshow_progress \
     --noshow_loading_progress \
     --test_arg="--image_version=${IMAGE_VERSION}" \

--- a/conda/test_conda.py
+++ b/conda/test_conda.py
@@ -67,7 +67,6 @@ class CondaTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             metadata=metadata)
 
         instance_name = self.getClusterName() + "-m"

--- a/dr-elephant/test_dr_elephant.py
+++ b/dr-elephant/test_dr_elephant.py
@@ -33,8 +33,7 @@ class DrElephantTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            timeout_in_minutes=30,
-            machine_type="n1-standard-2")
+            timeout_in_minutes=30)
 
         # Submit a job to check if statistic is generated
         self.assert_dataproc_job(

--- a/drill/test_drill.py
+++ b/drill/test_drill.py
@@ -34,8 +34,7 @@ class DrillTestCase(DataprocTestCase):
         init_actions = self.INIT_ACTIONS
         if configuration == "STANDARD":
             init_actions = self.INIT_ACTIONS_FOR_STANDARD + init_actions
-        self.createCluster(
-            configuration, init_actions, machine_type="n1-standard-2")
+        self.createCluster(configuration, init_actions)
 
         drill_mode = "DISTRIBUTED"
         if configuration == "SINGLE":

--- a/flink/test_flink.py
+++ b/flink/test_flink.py
@@ -29,8 +29,7 @@ class FlinkTestCase(DataprocTestCase):
         ("HA", ["m-0", "m-1", "m-2"]),
     )
     def test_flink(self, configuration, machine_suffixes):
-        self.createCluster(
-            configuration, self.INIT_ACTIONS, machine_type="n1-standard-2")
+        self.createCluster(configuration, self.INIT_ACTIONS)
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),
                                                 machine_suffix))
@@ -45,7 +44,6 @@ class FlinkTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             metadata="flink-start-yarn-session=false")
         for machine_suffix in machine_suffixes:
             self.verify_instance(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -29,7 +29,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
             metadata = "gpu-driver-provider={}".format(driver_provider)
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
-                           beta=True,
+                           machine_type='n1-standard-2',
                            master_accelerator=master_accelerator,
                            worker_accelerator=worker_accelerator,
                            metadata=metadata,
@@ -51,7 +51,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
             metadata += ",gpu-driver-provider={}".format(driver_provider)
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
-                           beta=True,
+                           machine_type='n1-standard-2',
                            master_accelerator=master_accelerator,
                            worker_accelerator=worker_accelerator,
                            metadata=metadata,
@@ -74,7 +74,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            beta=True,
+            machine_type='n1-standard-2',
             master_accelerator=master_accelerator,
             worker_accelerator=worker_accelerator,
             metadata=metadata,

--- a/h2o/test_h2o.py
+++ b/h2o/test_h2o.py
@@ -24,8 +24,7 @@ class H2OTestCase(DataprocTestCase):
         self.createCluster(configuration,
                            init_actions,
                            optional_components=optional_components,
-                           scopes="cloud-platform",
-                           machine_type="n1-standard-2")
+                           scopes="cloud-platform")
 
         self.assert_dataproc_job(
             self.name, "pyspark", "{}/{}".format(self.INIT_ACTIONS_REPO,

--- a/hbase/test_hbase.py
+++ b/hbase/test_hbase.py
@@ -41,8 +41,7 @@ class HBaseTestCase(DataprocTestCase):
         init_actions = self.INIT_ACTIONS
         if configuration != "HA":
             init_actions = self.INIT_ACTIONS_FOR_NOT_HA + init_actions
-        self.createCluster(
-            configuration, init_actions, machine_type="n1-standard-2")
+        self.createCluster(configuration, init_actions)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),
@@ -73,8 +72,7 @@ class HBaseTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             init_actions,
-            metadata=metadata,
-            machine_type="n1-standard-2")
+            metadata=metadata)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),

--- a/integration_tests/dataproc_test_case.py
+++ b/integration_tests/dataproc_test_case.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=os.getenv("LOG_LEVEL", logging.INFO))
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('image', None, 'Dataproc image URL')
-flags.DEFINE_string('image_version', None, 'Dataproc version, e.g. 1.4')
+flags.DEFINE_string('image_version', None, 'Dataproc image version, e.g. 1.4')
 flags.DEFINE_boolean('skip_cleanup', False, 'Skip cleanup of test resources')
 FLAGS(sys.argv)
 
@@ -95,7 +95,7 @@ class DataprocTestCase(parameterized.TestCase):
                       master_accelerator=None,
                       worker_accelerator=None,
                       optional_components=None,
-                      machine_type="n1-standard-1",
+                      machine_type="e2-standard-2",
                       boot_disk_size="50GB"):
         self.initClusterName(configuration)
         self.cluster_version = None
@@ -106,34 +106,41 @@ class DataprocTestCase(parameterized.TestCase):
         ]
 
         args = self.DEFAULT_ARGS[configuration].copy()
-        if properties:
-            args.append("--properties={}".format(properties))
-        if scopes:
-            args.append("--scopes={}".format(scopes))
-        if metadata:
-            args.append("--metadata={}".format(metadata))
         if FLAGS.image:
             args.append("--image={}".format(FLAGS.image))
         if FLAGS.image_version:
             args.append("--image-version={}".format(FLAGS.image_version))
-        if timeout_in_minutes:
-            args.append("--initialization-action-timeout={}m".format(
-                timeout_in_minutes))
-        if init_actions:
-            args.append("--initialization-actions='{}'".format(
-                ','.join(init_actions)))
-        if master_accelerator:
-            args.append("--master-accelerator={}".format(master_accelerator))
-        if worker_accelerator:
-            args.append("--worker-accelerator={}".format(worker_accelerator))
+
         if optional_components:
             args.append("--optional-components={}".format(
                 ','.join(optional_components)))
 
+        if init_actions:
+            args.append("--initialization-actions='{}'".format(
+                ','.join(init_actions)))
+        if timeout_in_minutes:
+            args.append("--initialization-action-timeout={}m".format(
+                timeout_in_minutes))
+
+        if properties:
+            args.append("--properties={}".format(properties))
+        if metadata:
+            args.append("--metadata={}".format(metadata))
+
+        if scopes:
+            args.append("--scopes={}".format(scopes))
+
+        if master_accelerator:
+            args.append("--master-accelerator={}".format(master_accelerator))
+        if worker_accelerator:
+            args.append("--worker-accelerator={}".format(worker_accelerator))
+
         args.append("--master-machine-type={}".format(machine_type))
         args.append("--worker-machine-type={}".format(machine_type))
+
         args.append("--master-boot-disk-size={}".format(boot_disk_size))
         args.append("--worker-boot-disk-size={}".format(boot_disk_size))
+
         args.append("--format=json")
 
         args.append("--region={}".format(self.REGION))

--- a/jupyter/test_jupyter.py
+++ b/jupyter/test_jupyter.py
@@ -29,8 +29,7 @@ class JupyterTestCase(DataprocTestCase):
             configuration,
             self.INIT_ACTIONS,
             metadata=metadata,
-            timeout_in_minutes=15,
-            machine_type="n1-standard-2")
+            timeout_in_minutes=15)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance(
@@ -55,8 +54,7 @@ class JupyterTestCase(DataprocTestCase):
             configuration,
             self.INIT_ACTIONS,
             metadata=metadata,
-            timeout_in_minutes=15,
-            machine_type="n1-standard-2")
+            timeout_in_minutes=15)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance(

--- a/jupyter_sparkmonitor/test_jupyter_sparkmonitor.py
+++ b/jupyter_sparkmonitor/test_jupyter_sparkmonitor.py
@@ -31,8 +31,7 @@ class JupyterTestCase(DataprocTestCase):
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
                            optional_components=self.OPTIONAL_COMPONENTS,
-                           timeout_in_minutes=10,
-                           machine_type="n1-standard-2")
+                           timeout_in_minutes=10)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),

--- a/kafka/test_kafka.py
+++ b/kafka/test_kafka.py
@@ -26,8 +26,7 @@ class KafkaTestCase(DataprocTestCase):
     @parameterized.parameters(
         ("HA", ["m-0", "m-1", "m-2"]), )
     def test_kafka(self, configuration, machine_suffixes):
-        self.createCluster(
-            configuration, self.INIT_ACTIONS, machine_type="n1-standard-2")
+        self.createCluster(configuration, self.INIT_ACTIONS)
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),
                                                 machine_suffix))

--- a/knox/test_knox.py
+++ b/knox/test_knox.py
@@ -36,7 +36,6 @@ class KnoxTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             # we don't want to run the auto update during the tests
             # since it overrides our changes in the tests.
             # So we assign cron date to 31/December. Hopefully
@@ -60,7 +59,6 @@ class KnoxTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             # we don't want to run the auto update during the tests
             # since it overrides our changes in the tests.
             # So we assign cron date to 31/December.

--- a/oozie/test_oozie.py
+++ b/oozie/test_oozie.py
@@ -32,7 +32,7 @@ class OozieTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-4",
+            machine_type="e2-standard-4",
             boot_disk_size="200GB")
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),

--- a/presto/test_presto.py
+++ b/presto/test_presto.py
@@ -90,8 +90,7 @@ class PrestoTestCase(DataprocTestCase):
         if self.getImageVersion() >= pkg_resources.parse_version("2.0"):
             return
 
-        self.createCluster(
-            configuration, self.INIT_ACTIONS, machine_type="n1-standard-2")
+        self.createCluster(configuration, self.INIT_ACTIONS)
         for machine_suffix in machine_suffixes:
             self.verify_instance(
                 "{}-{}".format(self.getClusterName(), machine_suffix),
@@ -107,7 +106,6 @@ class PrestoTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             metadata="presto-port=8060")
         for machine_suffix in machine_suffixes:
             machine_name = "{}-{}".format(self.getClusterName(),

--- a/ranger/test_ranger.py
+++ b/ranger/test_ranger.py
@@ -43,7 +43,6 @@ class RangerTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             metadata="ranger-port={},default-admin-password={}".format(
                 6080, "dataproc2019"))
         for machine_suffix in machine_suffixes:

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -47,10 +47,10 @@ class RapidsTestCase(DataprocTestCase):
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
                            metadata=metadata,
+                           machine_type='n1-standard-2',
                            master_accelerator=master_accelerator,
                            worker_accelerator=accelerator,
                            optional_components=['ANACONDA'],
-                           machine_type='n1-standard-2',
                            timeout_in_minutes=70)
 
         for machine_suffix in machine_suffixes:

--- a/starburst-presto/test_starburst_presto.py
+++ b/starburst-presto/test_starburst_presto.py
@@ -85,8 +85,7 @@ class StarburstPrestoTestCase(DataprocTestCase):
     )
     def test_starburst_presto(self, configuration, machine_suffixes,
                               coordinators, workers):
-        self.createCluster(
-            configuration, self.INIT_ACTIONS, machine_type="n1-standard-2")
+        self.createCluster(configuration, self.INIT_ACTIONS)
         for machine_suffix in machine_suffixes:
             self.verify_instance(
                 "{}-{}".format(self.getClusterName(), machine_suffix),
@@ -99,7 +98,6 @@ class StarburstPrestoTestCase(DataprocTestCase):
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            machine_type="n1-standard-2",
             metadata="presto-port=8060")
         for machine_suffix in machine_suffixes:
             machine_name = "{}-{}".format(self.getClusterName(),

--- a/tony/test_tony.py
+++ b/tony/test_tony.py
@@ -22,7 +22,7 @@ class TonYTestCase(DataprocTestCase):
             configuration,
             self.INIT_ACTIONS,
             timeout_in_minutes=30,
-            machine_type="n1-standard-4")
+            machine_type="e2-standard-4")
 
         # Verify a cluster using TensorFlow job
         self.assert_dataproc_job(
@@ -46,8 +46,7 @@ class TonYTestCase(DataprocTestCase):
         self.createCluster(
             "STANDARD",
             self.INIT_ACTIONS,
-            timeout_in_minutes=30,
-            machine_type="n1-standard-2")
+            timeout_in_minutes=30)
 
         self.assert_dataproc_job(
             self.name, 'hadoop', '''\


### PR DESCRIPTION
This PR improves integration tests efficiency by using cheaper E2 VMs and reduces tests parallelism to prevent hitting external addresses/IPs quota