### PR TITLE
[knox]: correct bucket name in README and install rsync to fix Debian 10-based images installation

### DIFF
--- a/knox/README.md
+++ b/knox/README.md
@@ -46,7 +46,7 @@ Knox installed as follows:
     CLUSTER_NAME=<cluster_name>
     gcloud dataproc clusters create ${CLUSTER_NAME} \
         --region ${REGION}
-        --initialization-actions gs://dataproc-initialization-actions-${REGION}/knox/knox.sh \
+        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/knox/knox.sh \
         --metadata knox-gw-config=gs://<GCS path to your Knox configuration directory>
     ```
 
@@ -112,7 +112,7 @@ REGION=<region>
 CLUSTER_NAME=<cluster_name>
 gcloud dataproc clusters create ${CLUSTER_NAME} \
     --region ${REGION}
-    --initialization-actions gs://dataproc-initialization-actions-${REGION}/knox/knox.sh \
+    --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/knox/knox.sh \
     --metadata knox-gw-config=<your knox configuration directory without gs:// prefix> \
     --properties="hive:hive.server2.thrift.http.port=10000,hive:hive.server2.thrift.http.path=cliservice,hive:hive.server2.transport.mode=http"
 ```

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -41,7 +41,7 @@ function retry_command() {
 }
 
 function install_dependencies() {
-  retry_command 'apt install -y knox jq python-pip'
+  retry_command 'apt install -y knox jq python-pip rsync'
   retry_command 'pip install yq'
 }
 

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -41,7 +41,7 @@ function retry_command() {
 }
 
 function install_dependencies() {
-  retry_command 'apt install -y knox jq python-pip rsync'
+  retry_command 'apt install -y knox jq rsync'
   retry_command 'pip install yq'
 }
 


### PR DESCRIPTION
I fixed the bucket address in the README.

Rsync is missing in Dataproc 1.5 image. I have added that to the list of software to download for compatibility. 