### PR TITLE
Enable use of GCS bucket as workflow file source for Oozie

### DIFF
--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -141,7 +141,7 @@ function install_oozie() {
     --name 'google.cloud.auth.service.account.enable' --value 'true' \
     --description 'Whether to use a service account for GCS authorization.
     Setting this property to `false` will disable use of service accounts for
-    authentication.'
+    authentication.' \
     --clobber
   
   if [ -e /usr/lib/hadoop/lib/gcs-connector.jar ]

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -125,7 +125,22 @@ function install_oozie() {
     --configuration_file "/etc/hadoop/conf/core-site.xml" \
     --name 'hadoop.proxyuser.oozie.groups' --value '*' \
     --clobber
+    
+  bdconfig set_property \
+    --configuration_file "/etc/oozie/conf/oozie-site.xml" \
+    --name 'oozie.service.HadoopAccessorService.supported.filesystems' --value "hdfs,gs" \
+    --clobber
 
+  bdconfig set_property \
+    --configuration_file "/etc/hadoop/conf/core-site.xml" \
+    --name 'fs.AbstractFileSystem.gs.impl' --value 'com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS' \
+    --clobber
+    
+  bdconfig set_property \
+    --configuration_file "/etc/hadoop/conf/core-site.xml" \
+    --name 'google.cloud.auth.service.account.enable' --value 'false' \
+    --clobber
+  
   # Detect if current node configuration is HA and then set oozie servers
   local additional_nodes
   additional_nodes=$(/usr/share/google/get_metadata_value attributes/dataproc-master-additional |

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -138,8 +138,16 @@ function install_oozie() {
     
   bdconfig set_property \
     --configuration_file "/etc/hadoop/conf/core-site.xml" \
-    --name 'google.cloud.auth.service.account.enable' --value 'false' \
+    --name 'google.cloud.auth.service.account.enable' --value 'true' \
+    --description 'Whether to use a service account for GCS authorization.
+    Setting this property to `false` will disable use of service accounts for
+    authentication.'
     --clobber
+  
+  if [ -e /usr/lib/hadoop/lib/gcs-connector.jar ]
+  then
+    cp /usr/lib/hadoop/lib/gcs-connector.jar /usr/lib/oozie/lib/gcs-connector.jar
+  fi
   
   # Detect if current node configuration is HA and then set oozie servers
   local additional_nodes

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -133,20 +133,19 @@ function install_oozie() {
 
   bdconfig set_property \
     --configuration_file "/etc/hadoop/conf/core-site.xml" \
-    --name 'fs.AbstractFileSystem.gs.impl' --value 'com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS' \
-    --clobber
-    
-  bdconfig set_property \
-    --configuration_file "/etc/hadoop/conf/core-site.xml" \
-    --name 'google.cloud.auth.service.account.enable' --value 'true' \
-    --description 'Whether to use a service account for GCS authorization.
-    Setting this property to `false` will disable use of service accounts for
-    authentication.' \
+    --name 'fs.AbstractFileSystem.gs.impl'
+    --value 'com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS' \
     --clobber
   
-  if [ -e /usr/lib/hadoop/lib/gcs-connector.jar ]
+  local gcs_connector_dir="/usr/local/share/google/dataproc/lib"
+  if [[ ! -d \$install_dir ]]; then
+    gcs_connector_dir="/usr/lib/hadoop/lib"
+  fi
+  
+  local gcs_connector_path="$gcs_connector_dir/gcs-connector.jar"
+  if [ -e $gcs_connector_path ]
   then
-    cp /usr/lib/hadoop/lib/gcs-connector.jar /usr/lib/oozie/lib/gcs-connector.jar
+    cp $gcs_connector_path /usr/lib/oozie/lib/gcs-connector.jar
   fi
   
   # Detect if current node configuration is HA and then set oozie servers

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -133,7 +133,7 @@ function install_oozie() {
 
   bdconfig set_property \
     --configuration_file "/etc/hadoop/conf/core-site.xml" \
-    --name 'fs.AbstractFileSystem.gs.impl'
+    --name 'fs.AbstractFileSystem.gs.impl' \
     --value 'com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS' \
     --clobber
   

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -128,7 +128,7 @@ function install_oozie() {
     
   bdconfig set_property \
     --configuration_file "/etc/oozie/conf/oozie-site.xml" \
-    --name 'oozie.service.HadoopAccessorService.supported.filesystems' --value "hdfs,gs" \
+    --name 'oozie.service.HadoopAccessorService.supported.filesystems' --value 'hdfs,gs' \
     --clobber
 
   bdconfig set_property \

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -138,12 +138,10 @@ function install_oozie() {
     --clobber
   
   local gcs_connector_dir="/usr/local/share/google/dataproc/lib"
-  if [[ ! -d \$install_dir ]]; then
+  if [[ ! -d $gcs_connector_dir ]]; then
     gcs_connector_dir="/usr/lib/hadoop/lib"
-  fi
-  
-  local gcs_connector_path="$gcs_connector_dir/gcs-connector.jar"
-  cp $gcs_connector_path /usr/lib/oozie/lib/gcs-connector.jar
+  fi  
+  cp "${gcs_connector_dir}/gcs-connector.jar" /usr/lib/oozie/lib/
   
   # Detect if current node configuration is HA and then set oozie servers
   local additional_nodes

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -143,10 +143,7 @@ function install_oozie() {
   fi
   
   local gcs_connector_path="$gcs_connector_dir/gcs-connector.jar"
-  if [ -e $gcs_connector_path ]
-  then
-    cp $gcs_connector_path /usr/lib/oozie/lib/gcs-connector.jar
-  fi
+  cp $gcs_connector_path /usr/lib/oozie/lib/gcs-connector.jar
   
   # Detect if current node configuration is HA and then set oozie servers
   local additional_nodes


### PR DESCRIPTION
Implemented based on [SO answer](https://stackoverflow.com/questions/61233551/how-to-use-gcs-bucket-as-workflow-file-source-for-oozie-in-dataproc/61237392#61237392).

Fixes #798 