### PR TITLE
[rapids][gpu] fix RAPIDS README and GPU default Debian links to support CUDA 10.1

### DIFF
--- a/gpu/BUILD
+++ b/gpu/BUILD
@@ -8,7 +8,7 @@ py_test(
     srcs = ["test_gpu.py"],
     data = ["install_gpu_driver.sh"],
     local = True,
-    shard_count = 9,
+    shard_count = 12,
     deps = [
         "//integration_tests:dataproc_test_case",
         "@io_abseil_py//absl/testing:parameterized",

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -107,23 +107,24 @@ script without NVIDIA Docker, you can find more information at
 #### Supported metadata parameters:
 
 -   `install-gpu-agent: true|false` - this is an optional parameter with
-    case-sensitive value.
+    case-sensitive value. Default is `false`.
 
     **Note:** This parameter will collect GPU utilization and send statistics to
     Stackdriver. Make sure you add the correct scope to access Stackdriver.
 
 -   `gpu-driver-provider: OS|NVIDIA` - this is an optional parameter with
-    case-sensitive value.
+    case-sensitive value. Default is `OS`.
 
 -   `gpu-driver-url: <URL>` - this is an optional parameter for customizing
     NVIDIA-provided GPU driver on Debian.
 
 -   `cuda-url: <URL>` - this is an optional parameter for customizing
-    NVIDIA-provided CUDA on Debian.
+    NVIDIA-provided CUDA on Debian. This is required if not using CUDA 10.1
+    or 10.2 with a Debian image. Please find the appropriate linux-based 
+    runtime-file URL [here](https://developer.nvidia.com/cuda-toolkit-archive).
 
--   `cuda-version: 10.0|10.1|10.2` - this is an optional parameter for
-    customizing NVIDIA-provided CUDA version on Ubuntu. If set to empty then the
-    latest available CUDA version will be installed.
+-   `cuda-version: 10.1|10.2|<VERSION>` - this is an optional parameter for
+    customizing NVIDIA-provided CUDA version. Default is `10.2`. 
 
 #### Verification
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -30,14 +30,24 @@ readonly OS_DIST
 # Dataproc role
 readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 
+# CUDA Version
+readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '10.2')
+
 # Parameters for NVIDIA-provided Debian GPU driver
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL='http://us.download.nvidia.com/XFree86/Linux-x86_64/450.51/NVIDIA-Linux-x86_64-450.51.run'
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
-readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL='http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
+readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_1='http://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run'
+readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_2='http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
+
+if [[ "${CUDA_VERSION}" == "10.1" ]]; then
+  readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL=${DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_1}
+else
+  readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL=${DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_2}
+fi
+
 readonly NVIDIA_DEBIAN_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_DEBIAN_CUDA_URL}")
 
 # Parameters for NVIDIA-provided Ubuntu GPU driver
-readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '10.2')
 readonly NVIDIA_UBUNTU_REPOSITORY_URL='https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64'
 readonly NVIDIA_UBUNTU_REPOSITORY_KEY="${NVIDIA_UBUNTU_REPOSITORY_URL}/7fa2af80.pub"
 readonly NVIDIA_UBUNTU_REPOSITORY_CUDA_PIN="${NVIDIA_UBUNTU_REPOSITORY_URL}/cuda-ubuntu1804.pin"
@@ -51,14 +61,12 @@ readonly NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.7.6')
 readonly NVIDIA_DRIVER_VERSION_UBUNTU='440'
 
 # Whether to install NVIDIA-provided or OS-provided GPU driver
-GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'OS')
-readonly GPU_DRIVER_PROVIDER
+readonly GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'OS')
 
 # Stackdriver GPU agent parameters
 readonly GPU_AGENT_REPO_URL='https://raw.githubusercontent.com/GoogleCloudPlatform/ml-on-gcp/master/dlvm/gcp-gpu-utilization-metrics'
 # Whether to install GPU monitoring agent that sends GPU metrics to Stackdriver
-INSTALL_GPU_AGENT=$(get_metadata_attribute 'install-gpu-agent' 'false')
-readonly INSTALL_GPU_AGENT
+readonly INSTALL_GPU_AGENT=$(get_metadata_attribute 'install-gpu-agent' 'false')
 
 # Dataproc configurations
 readonly HADOOP_CONF_DIR='/etc/hadoop/conf'

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -28,14 +28,17 @@ OS_DIST=$(lsb_release -cs)
 readonly OS_DIST
 
 # Dataproc role
-readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+readonly ROLE
 
 # CUDA Version
-readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '10.2')
+CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '10.2')
+readonly CUDA_VERSION
 
 # Parameters for NVIDIA-provided Debian GPU driver
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL='http://us.download.nvidia.com/XFree86/Linux-x86_64/450.51/NVIDIA-Linux-x86_64-450.51.run'
-readonly NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
+NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
+readonly NVIDIA_DEBIAN_GPU_DRIVER_URL
 readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_1='http://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run'
 readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_2='http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
 
@@ -45,7 +48,8 @@ else
   readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL=${DEFAULT_NVIDIA_DEBIAN_CUDA_URL_10_2}
 fi
 
-readonly NVIDIA_DEBIAN_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_DEBIAN_CUDA_URL}")
+NVIDIA_DEBIAN_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_DEBIAN_CUDA_URL}")
+readonly NVIDIA_DEBIAN_CUDA_URL
 
 # Parameters for NVIDIA-provided Ubuntu GPU driver
 readonly NVIDIA_UBUNTU_REPOSITORY_URL='https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64'
@@ -54,19 +58,23 @@ readonly NVIDIA_UBUNTU_REPOSITORY_CUDA_PIN="${NVIDIA_UBUNTU_REPOSITORY_URL}/cuda
 
 # Parameters for NVIDIA-provided NCCL library
 readonly DEFAULT_NCCL_REPO_URL='https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb'
-readonly NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}")
-readonly NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.7.6')
+NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}")
+readonly NCCL_REPO_URL
+NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.7.6')
+readonly NCCL_VERSION
 
 # Parameters for Ubuntu-provided NVIDIA GPU driver
 readonly NVIDIA_DRIVER_VERSION_UBUNTU='440'
 
 # Whether to install NVIDIA-provided or OS-provided GPU driver
-readonly GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'OS')
+GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'OS')
+readonly GPU_DRIVER_PROVIDER
 
 # Stackdriver GPU agent parameters
 readonly GPU_AGENT_REPO_URL='https://raw.githubusercontent.com/GoogleCloudPlatform/ml-on-gcp/master/dlvm/gcp-gpu-utilization-metrics'
 # Whether to install GPU monitoring agent that sends GPU metrics to Stackdriver
-readonly INSTALL_GPU_AGENT=$(get_metadata_attribute 'install-gpu-agent' 'false')
+INSTALL_GPU_AGENT=$(get_metadata_attribute 'install-gpu-agent' 'false')
+readonly INSTALL_GPU_AGENT
 
 # Dataproc configurations
 readonly HADOOP_CONF_DIR='/etc/hadoop/conf'

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -86,6 +86,24 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
             self.verify_instance_gpu_agent("{}-{}".format(
                 self.getClusterName(), machine_suffix))
 
-
+    @parameterized.parameters(
+        ("STANDARD", ["m"], GPU_V100, None, "NVIDIA"),
+        ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "NVIDIA"),
+        ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "NVIDIA"),
+    )
+    def test_install_gpu_cuda_10_1(self, configuration, machine_suffixes,
+                                       master_accelerator, worker_accelerator,
+                                       driver_provider):
+        metadata = "gpu-driver-provider={},cuda-version=10.1".format(driver_provider)
+        self.createCluster(configuration,
+                           self.INIT_ACTIONS,
+                           machine_type='n1-standard-2',
+                           master_accelerator=master_accelerator,
+                           worker_accelerator=worker_accelerator,
+                           metadata=metadata,
+                           timeout_in_minutes=30)
+        for machine_suffix in machine_suffixes:
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 if __name__ == '__main__':
     absltest.main()

--- a/rapids/README.md
+++ b/rapids/README.md
@@ -180,6 +180,7 @@ gcloud dataproc clusters create $CLUSTER_NAME \
     --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-${REGION}/rapids/rapids.sh \
     --metadata gpu-driver-provider=NVIDIA \
     --metadata rapids-runtime=SPARK \
+    --metadata cuda-version=10.1 \
     --bucket $GCS_BUCKET \
     --enable-component-gateway 
 ```

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -11,17 +11,14 @@ function get_metadata_attribute() {
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
 
 if [[ "${SPARK_VERSION_ENV}" == "3"* ]]; then
-    readonly DEFAULT_CUDA_VERSION="10.2"
     readonly DEFAULT_CUDF_VERSION="0.14"
     readonly DEFAULT_SPARK_RAPIDS_VERSION="0.1.0"
     readonly SPARK_VERSION="${SPARK_VERSION_ENV}"
 else
-    readonly DEFAULT_CUDA_VERSION="10.1"
     readonly DEFAULT_CUDF_VERSION="0.9.2"
     readonly DEFAULT_SPARK_RAPIDS_VERSION="Beta5"
     readonly SPARK_VERSION="2.x"
 fi
-
 
 readonly ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 readonly MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
@@ -30,6 +27,7 @@ readonly RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'DASK')
 readonly RUN_WORKER_ON_MASTER=$(get_metadata_attribute 'dask-cuda-worker-on-master' 'true')
 
 # RAPIDS config
+readonly DEFAULT_CUDA_VERSION="10.2"
 readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
 readonly CUDF_VERSION=$(get_metadata_attribute 'cudf-version' ${DEFAULT_CUDF_VERSION})
 readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' '0.14')

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -58,11 +58,15 @@ class RapidsTestCase(DataprocTestCase):
     def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
         if self.getImageVersion() < pkg_resources.parse_version("1.5"):
             return    
+        
+        metadata = 'gpu-driver-provider=NVIDIA,rapids-runtime=SPARK'
+        if self.getImageVersion() < pkg_resources.parse_version("2.0"):
+            metadata += ",cuda-version=10.1"
 
         self.createCluster(
             configuration,
             self.INIT_ACTIONS,
-            metadata='gpu-driver-provider=NVIDIA,rapids-runtime=SPARK',
+            metadata=metadata,
             machine_type='n1-standard-2',
             worker_accelerator=accelerator,
             timeout_in_minutes=30)


### PR DESCRIPTION
fix documentation for RAPIDS to include cuda 10.1 with Dataproc 1.5, update tests
add cuda 10.1 debian link to GPU init action, update tests

fixes https://github.com/GoogleCloudDataproc/initialization-actions/issues/791