### PR TITLE
Improve test runners bin packing

### DIFF
--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -11,7 +11,7 @@ readonly POD_NAME=presubmit-${DATAPROC_IMAGE_VERSION//./-}-${BUILD_ID//_/-}
 gcloud container clusters get-credentials "${CLOUDSDK_CONTAINER_CLUSTER}"
 
 kubectl run "${POD_NAME}" --generator=run-pod/v1 --image="$IMAGE" \
-  --requests "cpu=2,memory=4Gi" --restart=Never \
+  --requests "cpu=1.3,memory=4.9Gi" --restart=Never \
   --env="COMMIT_SHA=$COMMIT_SHA" \
   --env="IMAGE_VERSION=$DATAPROC_IMAGE_VERSION" \
   --command -- bash /init-actions/cloudbuild/presubmit.sh


### PR DESCRIPTION
This configuration allows to run 6 test runners/pods on one 8-node k8s node