### PR TITLE
[knox] Create 2048 bit certificates in Dataproc versions that use Knox version 1.1

### DIFF
--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -41,7 +41,11 @@ function retry_command() {
 }
 
 function install_dependencies() {
+<<<<<<< HEAD
   retry_command 'apt install -y knox jq rsync'
+=======
+  retry_command 'apt install -y knox jq python-pip rsync'
+>>>>>>> corrects the init action bucket address and adds rsync to the list of applications needed for 1.5 release
   retry_command 'pip install yq'
 }
 

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -41,11 +41,7 @@ function retry_command() {
 }
 
 function install_dependencies() {
-<<<<<<< HEAD
   retry_command 'apt install -y knox jq rsync'
-=======
-  retry_command 'apt install -y knox jq python-pip rsync'
->>>>>>> corrects the init action bucket address and adds rsync to the list of applications needed for 1.5 release
   retry_command 'pip install yq'
 }
 


### PR DESCRIPTION
Knox init action creates example certificates to support TLS. In older versions of knox (< 1.3), the knoxcli creates 1024 bit certificates, which are not strong enough and curl in Debian 10 rejects them. So we create these certificates by using java keytool instead of knoxcli in old versions. In the latest dataproc 1.5 with Knox 1.3, still knoxcli creates the certificates.