### PR TITLE
Deprecate Jupyter Spark Monitor init action for 2.0+

### DIFF
--- a/jupyter_sparkmonitor/README.md
+++ b/jupyter_sparkmonitor/README.md
@@ -1,3 +1,15 @@
+--------------------------------------------------------------------------------
+
+# NOTE: *The Jupyter Spark Monitor initialization action has been deprecated. Please use the Jupyter Component*
+
+**The
+[Jupyter Component](https://cloud.google.com/dataproc/docs/concepts/components/jupyter)
+is the best way to use Jupyter with Cloud Dataproc. To learn more about
+Dataproc Components see
+[here](https://cloud.google.com/dataproc/docs/concepts/components/overview).**
+
+--------------------------------------------------------------------------------
+
 # Jupyter Notebook with SparkMonitor
 
 This folder contains the initialization action `sparkmonitor.sh` to quickly

--- a/jupyter_sparkmonitor/sparkmonitor.sh
+++ b/jupyter_sparkmonitor/sparkmonitor.sh
@@ -20,6 +20,9 @@
 
 set -euxo pipefail
 
+readonly NOT_SUPPORTED_MESSAGE="Jupyter Spark Monitor initialization action is not supported on Dataproc ${DATAPROC_VERSION}."
+[[ $DATAPROC_VERSION != 1.* ]] && echo "$NOT_SUPPORTED_MESSAGE" && exit 1
+
 source '/usr/local/share/google/dataproc/bdutil/bdutil_helpers.sh'
 
 readonly SPARKMONITOR_VERSION=0.0.11

--- a/jupyter_sparkmonitor/test_jupyter_sparkmonitor.py
+++ b/jupyter_sparkmonitor/test_jupyter_sparkmonitor.py
@@ -6,41 +6,41 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 
 
 class JupyterTestCase(DataprocTestCase):
-    OPTIONAL_COMPONENTS = ['ANACONDA', 'JUPYTER']
-    COMPONENT = 'sparkmonitor'
-    INIT_ACTIONS = ['jupyter_sparkmonitor/sparkmonitor.sh']
+  OPTIONAL_COMPONENTS = ["ANACONDA", "JUPYTER"]
+  COMPONENT = "sparkmonitor"
+  INIT_ACTIONS = ["jupyter_sparkmonitor/sparkmonitor.sh"]
 
-    def verify_instance(self, name, jupyter_port):
-        verify_cmd_pip_check = "/opt/conda/default/bin/pip list | grep sparkmonitor"
-        self.assert_instance_command(name, verify_cmd_pip_check)
+  def verify_instance(self, name, jupyter_port):
+    verify_cmd_pip_check = "/opt/conda/default/bin/pip list | grep sparkmonitor"
+    self.assert_instance_command(name, verify_cmd_pip_check)
 
-        verify_cmd = "curl {} -L {}:{} | grep 'Jupyter Notebook'".format(
-            "--retry 10 --retry-delay 10 --retry-connrefused", name,
-            jupyter_port)
-        self.assert_instance_command(name, verify_cmd)
+    verify_cmd = "curl {} -L {}:{} | grep 'Jupyter Notebook'".format(
+        "--retry 10 --retry-delay 10 --retry-connrefused", name, jupyter_port)
+    self.assert_instance_command(name, verify_cmd)
 
-    @parameterized.parameters(
-        ("SINGLE", ["m"]),
-        ("STANDARD", ["m"]),
-    )
-    def test_sparkmonitor(self, configuration, machine_suffixes):
-        # Use 1.4 version of Dataproc to test because it requires Python 3
-        if self.getImageVersion() < pkg_resources.parse_version("1.4"):
-            return
+  @parameterized.parameters(
+      ("SINGLE", ["m"]),
+      ("STANDARD", ["m"]),
+  )
+  def test_sparkmonitor(self, configuration, machine_suffixes):
+    # Use 1.4 version of Dataproc to test because it requires Python 3
+    if self.getImageVersion() < pkg_resources.parse_version("1.4"):
+      return
 
-        if self.getImageVersion() >= pkg_resources.parse_version("2.0"):
-          self.skipTest("Not supported in 2.0+ images")
+    if self.getImageVersion() >= pkg_resources.parse_version("2.0"):
+      self.skipTest("Not supported in 2.0+ images")
 
-        self.createCluster(configuration,
-                           self.INIT_ACTIONS,
-                           optional_components=self.OPTIONAL_COMPONENTS,
-                           timeout_in_minutes=10)
+    self.createCluster(
+        configuration,
+        self.INIT_ACTIONS,
+        optional_components=self.OPTIONAL_COMPONENTS,
+        timeout_in_minutes=10)
 
-        for machine_suffix in machine_suffixes:
-            self.verify_instance("{}-{}".format(self.getClusterName(),
-                                                machine_suffix),
-                                 jupyter_port="8123")
+    for machine_suffix in machine_suffixes:
+      self.verify_instance(
+          "{}-{}".format(self.getClusterName(), machine_suffix),
+          jupyter_port="8123")
 
 
-if __name__ == '__main__':
-    absltest.main()
+if __name__ == "__main__":
+  absltest.main()

--- a/jupyter_sparkmonitor/test_jupyter_sparkmonitor.py
+++ b/jupyter_sparkmonitor/test_jupyter_sparkmonitor.py
@@ -28,6 +28,9 @@ class JupyterTestCase(DataprocTestCase):
         if self.getImageVersion() < pkg_resources.parse_version("1.4"):
             return
 
+        if self.getImageVersion() >= pkg_resources.parse_version("2.0"):
+          self.skipTest("Not supported in 2.0+ images")
+
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
                            optional_components=self.OPTIONAL_COMPONENTS,


### PR DESCRIPTION
**Rationale:** Jupyter Spark Monitor is not supported for Spark 3.