### PR TITLE
[gpu][rapids] Downgrade default CUDA version to 10.2

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -32,7 +32,7 @@ ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly ROLE
 
 # CUDA Version
-CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '11.0')
+CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '10.2')
 readonly CUDA_VERSION
 
 # Parameters for NVIDIA-provided Debian GPU driver

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -27,7 +27,7 @@ readonly RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'DASK')
 readonly RUN_WORKER_ON_MASTER=$(get_metadata_attribute 'dask-cuda-worker-on-master' 'true')
 
 # RAPIDS config
-readonly DEFAULT_CUDA_VERSION="11.0"
+readonly DEFAULT_CUDA_VERSION="10.2"
 readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
 readonly CUDF_VERSION=$(get_metadata_attribute 'cudf-version' ${DEFAULT_CUDF_VERSION})
 readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' '0.15')


### PR DESCRIPTION
Signed-off-by: Sameer Raheja <sraheja@nvidia.com>

After making the default CUDA version 11.0 for the rapids.sh initialization scripts, we realized that one of our components, RAPIDS Spark XGBoost, is not yet working with 11.0.  We would like to change the default to 10.2 until this component is working with 11.0, which will happen by the end of the year.  

cc: @mengdong @garyshen2008 