### PR TITLE
[rapids] fixing RAPIDS dependency issue

### DIFF
--- a/integration_tests/dataproc_test_case.py
+++ b/integration_tests/dataproc_test_case.py
@@ -94,6 +94,8 @@ class DataprocTestCase(parameterized.TestCase):
                       beta=False,
                       master_accelerator=None,
                       worker_accelerator=None,
+                      image=None,
+                      image_version=None,
                       optional_components=None,
                       machine_type="e2-standard-2",
                       boot_disk_size="50GB"):
@@ -106,8 +108,12 @@ class DataprocTestCase(parameterized.TestCase):
         ]
 
         args = self.DEFAULT_ARGS[configuration].copy()
-        if FLAGS.image:
+        if image:
+            args.append("--image={}".format(image))
+        elif FLAGS.image:
             args.append("--image={}".format(FLAGS.image))
+        elif image_version:
+            args.append("--image-version={}".format(image_version))
         elif FLAGS.image_version:
             args.append("--image-version={}".format(FLAGS.image_version))
 
@@ -198,6 +204,15 @@ class DataprocTestCase(parameterized.TestCase):
 
     def getClusterName(self):
         return self.name
+
+    @staticmethod
+    def getBaseOS():
+        # Get the base operating system: '1.5-debian10' -> 'debian'
+        # Dataproc default version is Debian, therfore "debian" is returned
+        # if another OS cannot be identified.
+        search = re.search("([a-z]+)[0-9]*$", FLAGS.image_version)
+        return search.groups()[0] if search and search.groups()[0] != "preview" \
+            else "debian"
 
     @staticmethod
     def getImageVersion():

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -59,27 +59,22 @@ function execute_with_retries() {
 function install_dask_rapids() {
   local base
   base=$(conda info --base)
-  local -r pinned=${base}/conda-meta/pinned
   local -r mamba_env=mamba
   
   # Using mamba significantly reduces the conda solve-time. Create a separate conda
   # environment with mamba installed to manage installations.
   conda create -y -n ${mamba_env} -c conda-forge mamba
 
-  # RAPIDS releases require fixed PyArrow versions. Unpin PyArrow to solve
-  # for new environment.
-  sed -i '/pyarrow .*/d' ${pinned}
+  # Uninstall dependency "icu"
+  conda remove --force icu
 
-  # Install RAPIDS and cudatoolkit. Use mamba in new env to resolve base environment
+  # Install RAPIDS, cudatoolkit. Use mamba in new env to resolve base environment
+  # Dependency "icu" is also reinstalled here. 
   ${base}/envs/${mamba_env}/bin/mamba install -y \
     -c "rapidsai" -c "nvidia" -c "conda-forge" -c "defaults" \
     "cudatoolkit=${CUDA_VERSION}" "rapids=${RAPIDS_VERSION}" \
+    "icu" \
     -p ${base}
-
-  # Repin PyArrow with new version
-  local version
-  version=$(conda list pyarrow | grep -E pyarrow 2>&1 | sed -n 's/pyarrow[[:blank:]]\+\([0-9\.]\+\).*/\1/p')
-  echo "pyarrow ${version}.*" >> ${pinned}
 
   # Remove mamba env
   conda env remove -n ${mamba_env}

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -77,6 +77,16 @@ class RapidsTestCase(DataprocTestCase):
   def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
     if self.getImageVersion() < pkg_resources.parse_version("1.5"):
       self.skipTest("Not supported in pre 1.5 images")
+    
+    # Pin preview image as RAPIDS is not yet supported on Spark 3.1
+    image_version = None
+    if self.getImageVersion() == pkg_resources.parse_version("2.0"):
+      if self.getBaseOS() == "debian":
+        image_version == "2.0.0-RC22-debian10"
+      elif self.getBaseOS == "ubuntu":
+        image_version == "2.0.0-RC22-ubuntu18"
+      else:
+        self.skipTest("Unsupported OS")
 
     optional_components = None
     metadata = "gpu-driver-provider=NVIDIA,rapids-runtime=SPARK"
@@ -91,6 +101,7 @@ class RapidsTestCase(DataprocTestCase):
         metadata=metadata,
         machine_type="n1-standard-4",
         worker_accelerator=accelerator,
+        image_version=image_version
         timeout_in_minutes=30)
 
     for machine_suffix in machine_suffixes:


### PR DESCRIPTION
There is a dependency conflict with "icu" that conda is unable to solve on it's own. Uninstall it and reinstall with RAPIDS to get correct version and fix the environment.

Also, as we no longer pin PyArrow in 2.0, I removed the logic that was concerned with that.

@mengdong @sameerz FYI