### PR TITLE
[ganglia] Fix overview page for Dataproc cluster

### DIFF
--- a/ganglia/ganglia.sh
+++ b/ganglia/ganglia.sh
@@ -41,6 +41,7 @@ function setup_ganglia_host() {
 
   ln -s /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf
   sed -i "s/my cluster/${master_hostname}/" /etc/ganglia/gmetad.conf
+  sed -i '26s/ \$context_metrics \= \"\"\;/ \$context_metrics \= array\(\)\;/g' /usr/share/ganglia-webfrontend/cluster_view.php
   systemctl restart ganglia-monitor gmetad apache2
 }
 


### PR DESCRIPTION
according to the https://github.com/ganglia/ganglia-web/issues/303 it is bug of ganglia-web itself

as well same fix was applied by Amazon on EMR

https://aws.amazon.com/premiumsupport/knowledge-center/ganglia-overview-page-blank-emr/