### PR TITLE
[dr-elephant] Add Supported Spark Version to README

### DIFF
--- a/dr-elephant/README.md
+++ b/dr-elephant/README.md
@@ -23,3 +23,7 @@ Once the cluster has been created, Dr. Elephant is configured to run on port
 [connecting to cluster web interfaces](https://cloud.google.com/dataproc/docs/concepts/cluster-web-interfaces).
 
 Your jobs statistics should be there.
+
+## Supported Spark Versions
+As of Janurary 19th, 2021, [Dr. Elephant only supports Spark < 2.2.3](https://github.com/linkedin/dr-elephant/issues/683)
+

--- a/dr-elephant/README.md
+++ b/dr-elephant/README.md
@@ -25,5 +25,6 @@ Once the cluster has been created, Dr. Elephant is configured to run on port
 Your jobs statistics should be there.
 
 ## Supported Spark Versions
-As of Janurary 19th, 2021, [Dr. Elephant only supports Spark < 2.2.3](https://github.com/linkedin/dr-elephant/issues/683)
 
+As of Janurary 19th, 2021,
+[Dr. Elephant only supports Spark < 2.2.3](https://github.com/linkedin/dr-elephant/issues/683)


### PR DESCRIPTION
Updating README as per issue created at https://github.com/GoogleCloudDataproc/initialization-actions/issues/856 to alert users that Dr. Elephant only works for Spark Versions 2.2.3 and below currently

Fixes #856