### PR TITLE
[tony] Update TonY and TF versions, remove PyTorch support

### DIFF
--- a/tony/BUILD
+++ b/tony/BUILD
@@ -4,9 +4,12 @@ py_test(
     name = "test_tony",
     size = "enormous",
     srcs = ["test_tony.py"],
-    data = ["tony.sh"],
+    data = [
+        "tony.sh",
+        "//gpu:install_gpu_driver.sh"
+    ],
     local = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//integration_tests:dataproc_test_case",
         "@io_abseil_py//absl/testing:parameterized",

--- a/tony/README.md
+++ b/tony/README.md
@@ -19,7 +19,7 @@ You can use this initialization action to create a new Dataproc cluster with Ton
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/tony/tony.sh
     ```
 
-    You can also pass specific metadata:
+    You can pass specific metadata:
     
     ```bash
     REGION=<region>
@@ -27,6 +27,20 @@ You can use this initialization action to create a new Dataproc cluster with Ton
     gcloud dataproc clusters create ${CLUSTER_NAME} \
         --region ${REGION} \
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/tony/tony.sh \
+        --metadata name1=value1,name2=value2... 
+    ```
+
+    You can also create a cluster with GPUs:
+    
+    ```bash
+    REGION=<region>
+    CLUSTER_NAME=<cluster_name>
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --region ${REGION} \
+        --master-aceelerator=nvidia-tesla-v100 \
+        --worker-aceelerator=nvidia-tesla-v100 \
+        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-${REGION}/tony/tony.sh \
+        --metadata gpu-driver-provider=NVIDIA \
         --metadata name1=value1,name2=value2... 
     ```
     
@@ -37,8 +51,6 @@ You can use this initialization action to create a new Dataproc cluster with Ton
      - ps_instances
      - ps_memory
      - tensorflow version
-     - pytorch version
-     - torch vision version
      - tf_gpu
         
     These parameters are defined here: TonY [configurations](https://github.com/linkedin/TonY/wiki/TonY-Configurations)
@@ -70,10 +82,9 @@ You can use this initialization action to create a new Dataproc cluster with Ton
     ```bash
     /opt/tony/TonY-samples
     ```
-    By default we install two examples:
+    By default we install examples for Tensorflow.
     
     - TensorFlow
-    - PyTorch
     
 For more information and to run some TonY examples, take a look at [TonY examples](https://github.com/linkedin/TonY/tree/master/tony-examples)
 A working example can be found on validate.sh
@@ -84,13 +95,12 @@ You can easily test TonY is running by using ```validate.sh ${cluster_prefix} ${
 * ```cluster_prefix``` argument sets a prefix in created cluster name
 * ```bucket_name``` argument sets a place where init action will be placed
 
-This script is used for testing TonY using 1.3 Dataproc images with standard configurations. 
+This script is used for testing TonY using 1.5 Dataproc images with standard configurations.
 After clusters are created, script submits Hadoop jobs on them.
-
 
 ## Important notes
 
-* This script will install TonY in the master node only
-* Virtual environments are installed for both TensorFlow and PyTorch examples.
-* TonY is supported with STANDARD configuration (1 master/2+ workers) in Dataproc 1.3.
-* TonY supports GPU using Hadoop 3.1 (YARN-6223). Currently not supported with Dataproc
+* This script will install TonY in the master node only.
+* Virtual environments are installed for only for TensorFlow examples.
+* TonY is supported with STANDARD configuration (1 master/2+ workers) in Dataproc 1.5+.
+* TonY supports GPU using Hadoop 3.1 (YARN-6223). To access this, you must use Dataproc 2.0+.

--- a/tony/test_tony.py
+++ b/tony/test_tony.py
@@ -8,15 +8,17 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 class TonYTestCase(DataprocTestCase):
     COMPONENT = 'tony'
     INIT_ACTIONS = ['tony/tony.sh']
+    GPU_V100 = "type=nvidia-tesla-v100"
+    GPU_INIT_ACTIONS = ['gpu/install_gpu_driver.sh'] + INIT_ACTIONS
 
     @parameterized.parameters(
         "SINGLE",
         "STANDARD",
     )
     def test_tony_tf(self, configuration):
-        # Init action supported on Dataproc 1.3+
-        if self.getImageVersion() < pkg_resources.parse_version("1.3"):
-            self.skipTest("Not supported in pre 1.3 images")
+        # Init action supported on Dataproc 1.5+
+        if self.getImageVersion() < pkg_resources.parse_version("1.5"):
+            self.skipTest("Not supported in pre 1.5 images")
 
         self.createCluster(
             configuration,
@@ -28,37 +30,48 @@ class TonYTestCase(DataprocTestCase):
         self.assert_dataproc_job(
             self.name, 'hadoop', '''\
                 --class=com.linkedin.tony.cli.ClusterSubmitter \
-                --jars=file:///opt/tony/TonY-samples/tony-cli-all.jar \
+                --jars=file:///opt/tony/TonY-samples/tony-cli.jar \
                 -- \
                 --src_dir=/opt/tony/TonY-samples/jobs/TFJob/src \
                 --task_params="--data_dir /tmp --working_dir /tmp" \
                 --conf_file=/opt/tony/TonY-samples/jobs/TFJob/tony.xml \
-                --executes=mnist_distributed.py \
+                --executes=mnist_keras_distributed.py \
                 --python_venv=/opt/tony/TonY-samples/deps/tf.zip \
                 --python_binary_path=tf/bin/python3
             ''')
 
-    def test_tony_torch(self):
-        # Init action supported on Dataproc 1.3+
-        if self.getImageVersion() < pkg_resources.parse_version("1.3"):
-            self.skipTest("Not supported in pre 1.3 images")
 
+    @parameterized.parameters(
+        "SINGLE",
+        "STANDARD",
+    )
+    def test_tony_tf_gpu(self, configuration):
+        # Init action supported on Dataproc 1.5+
+        if self.getImageVersion() < pkg_resources.parse_version("2.0"):
+            self.skipTest("TonY with GPUs not supported in pre 2.0 images")
+
+        metadata ="tf_gpu=true,cuda-version=11.0,cudnn-version=8.0.5.39"
         self.createCluster(
-            "STANDARD",
-            self.INIT_ACTIONS,
-            timeout_in_minutes=30)
+            configuration,
+            self.GPU_INIT_ACTIONS,
+            timeout_in_minutes=30,
+            metadata=metadata,
+            master_accelerator=self.GPU_V100,
+            worker_accelerator=self.GPU_V100,
+            machine_type="n1-standard-4")
 
+        # Verify a cluster using TensorFlow job
         self.assert_dataproc_job(
             self.name, 'hadoop', '''\
                 --class=com.linkedin.tony.cli.ClusterSubmitter \
-                --jars=file:///opt/tony/TonY-samples/tony-cli-all.jar \
+                --jars=file:///opt/tony/TonY-samples/tony-cli.jar \
                 -- \
-                --src_dir=/opt/tony/TonY-samples/jobs/PTJob/src \
-                --task_params="--root /tmp" \
-                --conf_file=/opt/tony/TonY-samples/jobs/PTJob/tony.xml \
-                --executes=mnist_distributed.py \
-                --python_venv=/opt/tony/TonY-samples/deps/pytorch.zip \
-                --python_binary_path=pytorch/bin/python3
+                --src_dir=/opt/tony/TonY-samples/jobs/TFJob/src \
+                --task_params="--data_dir /tmp --working_dir /tmp" \
+                --conf_file=/opt/tony/TonY-samples/jobs/TFJob/tony.xml \
+                --executes=mnist_keras_distributed.py \
+                --python_venv=/opt/tony/TonY-samples/deps/tf.zip \
+                --python_binary_path=tf/bin/python3
             ''')
 
 


### PR DESCRIPTION
Updating TonY and TensorFlow versions.

The version of PyTorch in this init action is also very old. I wasn't able to get this to work with an updated version so I dropped support for it in this init action.  

Also ack:
https://github.com/GoogleCloudDataproc/initialization-actions/issues/833
https://github.com/GoogleCloudDataproc/initialization-actions/issues/834