### PR TITLE
[cloud-sql-proxy] Validate that beeline works only if hive-server2 service is already running

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -302,7 +302,7 @@ function run_validation() {
   # Validate it's functioning.
   # On newer Dataproc images, we start hive-server2 after init actions are run,
   # so skip this step if hive-server2 isn't already running.
-  if (systemctl is-running --quiet hive-server2); then
+  if (systemctl show -p SubState --value hive-server2 | grep -q running); then
     local hiveserver_uri
     hiveserver_uri=$(get_hiveserver_uri)
     if ! timeout 60s beeline -u "${hiveserver_uri}" -e 'SHOW TABLES;' >&/dev/null; then

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -300,14 +300,17 @@ function run_validation() {
     err 'Run /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom <schema-version> to upgrade the schema. Note that this may break Hive metastores that depend on the old schema'
 
   # Validate it's functioning.
-  local hiveserver_uri
-  hiveserver_uri=$(get_hiveserver_uri)
-  if ! timeout 60s beeline -u "${hiveserver_uri}" -e 'SHOW TABLES;' >&/dev/null; then
-    err 'Failed to bring up Cloud SQL Metastore'
-  else
-    echo 'Cloud SQL Hive Metastore initialization succeeded' >&2
+  # On newer Dataproc images, we start hive-server2 after init actions are run,
+  # so skip this step if hive-server2 isn't already running.
+  if (systemctl is-running --quiet hive-server2); then
+    local hiveserver_uri
+    hiveserver_uri=$(get_hiveserver_uri)
+    if ! timeout 60s beeline -u "${hiveserver_uri}" -e 'SHOW TABLES;' >&/dev/null; then
+      err 'Failed to bring up Cloud SQL Metastore'
+    else
+      echo 'Cloud SQL Hive Metastore initialization succeeded' >&2
+    fi
   fi
-
 }
 
 function configure_hive_warehouse_dir() {


### PR DESCRIPTION
Context: On newer Dataproc images, we will wait to start hive-server2 until after init actions have been run.

Because of this, we shouldn't try to validate that we can talk to hive-server2 unless it is already running, which will be the case on older Dataproc images.