### PR TITLE
Update cloudbuild.yaml to remove CentOS tests

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -53,17 +53,6 @@ steps:
       - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
-  # Run presubmit tests in parallel for 1.5 CentOS image
-  - name: 'gcr.io/cloud-builders/kubectl'
-    id: 'dataproc-1.5-centos8-tests'
-    waitFor: ['gcr-push']
-    entrypoint: 'bash'
-    args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-centos8']
-    env:
-      - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
-      - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
-
   # Run presubmit tests in parallel for 1.5 Debian image
   - name: 'gcr.io/cloud-builders/kubectl'
     id: 'dataproc-1.5-debian10-tests'


### PR DESCRIPTION
CentOS is not yet supported by init actions.