### PR TITLE
[gpu] clean up and fix 2.0 clusters w/ master-only GPUs

### DIFF
--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -22,6 +22,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         name, "sudo ldconfig -p | grep -q libcudnn" )
 
   @parameterized.parameters(
+      ("SINGLE", ["m"], GPU_V100, None, None),
       ("STANDARD", ["m"], GPU_V100, None, None),
       ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "OS"),
       ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "NVIDIA"),
@@ -98,11 +99,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                                     machine_suffix))
 
   @parameterized.parameters(
-      ("STANDARD", ["m"], GPU_V100, None, "10.1"),
-      ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "10.1"),
-      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "10.1"),
-      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "10.2"),
-      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "11.0"),
+      ("SINGLE", ["m"], GPU_V100, None, "10.1"),
+      ("STANDARD", ["m"], GPU_V100, None, "10.2"),
+      ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "11.0"),
       ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "11.1"),
   )
   def test_install_gpu_cuda_nvidia(self, configuration, machine_suffixes,


### PR DESCRIPTION
Changes:
- configure YARN NodeManager to use GPUs only if GPUs are attached to the node (fixes 2.0 clusters creation with GPUs attached only to master nodes)
- install NCCL only if cuDNN installed
- code clean up
- run tests for single-node clusters