### PR TITLE
create home dir for livy user

### DIFF
--- a/livy/livy.sh
+++ b/livy/livy.sh
@@ -90,7 +90,9 @@ function main() {
   ln -s "/usr/local/lib/${LIVY_PKG_NAME}" "${LIVY_DIR}"
 
   # Create Livy user.
-  useradd -G hadoop livy
+  useradd -G hadoop livy -d /home/livy
+  mkdir -p /home/livy
+  chown livy:hadoop /home/livy
 
   # Setup livy package.
   chown -R -L livy:livy "${LIVY_DIR}"


### PR DESCRIPTION
Need to have home dir for livy as in some cases it will contain **.cache** folder for **Python-Eggs** 
Missing home will cause spark-submit to fail