### PR TITLE
[rapids] Rapids Spark v0.4.0 release

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -372,12 +372,11 @@ function main() {
   # This configuration should be ran on all nodes
   # regardless if they have attached GPUs
   configure_yarn
-
+  configure_yarn_nodemanager
+  configure_gpu_isolation
+    
   # Detect NVIDIA GPU
   if (lspci | grep -q NVIDIA); then
-    configure_yarn_nodemanager
-    configure_gpu_isolation
-
     execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
 
     if [[ ${GPU_DRIVER_PROVIDER} == 'NVIDIA' ]]; then

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -372,11 +372,14 @@ function main() {
   # This configuration should be ran on all nodes
   # regardless if they have attached GPUs
   configure_yarn
-  configure_yarn_nodemanager
-  configure_gpu_isolation
-    
+  
+  if [[ "${ROLE}" == "Master" ]]; then
+    configure_yarn_nodemanager
+    configure_gpu_isolation    
   # Detect NVIDIA GPU
-  if (lspci | grep -q NVIDIA); then
+  elif (lspci | grep -q NVIDIA); then
+    configure_yarn_nodemanager
+    configure_gpu_isolation
     execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
 
     if [[ ${GPU_DRIVER_PROVIDER} == 'NVIDIA' ]]; then
@@ -400,9 +403,7 @@ function main() {
       echo 'GPU metrics agent will not be installed.'
     fi
 
-    if [[ "${ROLE}" != "Master" ]]; then
-      configure_gpu_exclusive_mode
-    fi
+    configure_gpu_exclusive_mode
   fi
 }
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -373,11 +373,8 @@ function main() {
   # regardless if they have attached GPUs
   configure_yarn
   
-  if [[ "${ROLE}" == "Master" ]]; then
-    configure_yarn_nodemanager
-    configure_gpu_isolation    
   # Detect NVIDIA GPU
-  elif (lspci | grep -q NVIDIA); then
+  if (lspci | grep -q NVIDIA); then
     configure_yarn_nodemanager
     configure_gpu_isolation
     execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
@@ -404,6 +401,9 @@ function main() {
     fi
 
     configure_gpu_exclusive_mode
+  elif [[ "${ROLE}" == "Master" ]]; then
+    configure_yarn_nodemanager
+    configure_gpu_isolation
   fi
 }
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -70,7 +70,7 @@ readonly CUDNN_TARBALL="cudnn-${CUDA_VERSION}-linux-x64-v${CUDNN_VERSION}.tgz"
 readonly CUDNN_TARBALL_URL="http://developer.download.nvidia.com/compute/redist/cudnn/v${CUDNN_VERSION%.*}/${CUDNN_TARBALL}"
 
 # Whether to install NVIDIA-provided or OS-provided GPU driver
-GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'OS')
+GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'NVIDIA')
 readonly GPU_DRIVER_PROVIDER
 
 # Stackdriver GPU agent parameters

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -377,6 +377,7 @@ function main() {
   if (lspci | grep -q NVIDIA); then
     configure_yarn_nodemanager
     configure_gpu_isolation
+
     execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
 
     if [[ ${GPU_DRIVER_PROVIDER} == 'NVIDIA' ]]; then

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -372,7 +372,7 @@ function main() {
   # This configuration should be ran on all nodes
   # regardless if they have attached GPUs
   configure_yarn
-  
+
   # Detect NVIDIA GPU
   if (lspci | grep -q NVIDIA); then
     configure_yarn_nodemanager

--- a/rapids/README.md
+++ b/rapids/README.md
@@ -15,15 +15,15 @@ action supports Dask and Spark runtimes for RAPIDS on
 initialization actions in production.
 
 This initialization action will install RAPIDS on Dataproc for either Spark or
-Dask. RAPIDS for Spark is supported on Dataproc 2.0+ (Spark 3.0)+. 
-Spark with XGBoost is support on Dataproc 1.5+ with Spark 2.4.
-RAPIDS for Dask is only supported on Dataproc 2.0+.
+Dask. RAPIDS Accelerator For Apache Spark is supported on Dataproc 2.0+ (Spark 3.0)+. 
+Spark with RAPIDS XGBoost is support on Dataproc 1.5+ with Spark 2.4.
+RAPIDS Accelerator For Dask is only supported on Dataproc 2.0+.
 
-## Spark RAPIDS Accelerator
+## RAPIDS Accelerator For Apache Spark
 
 ### Prerequisites
 
-To use Spark Rapids SQL plugin, XGBoost4j with Spark 3
+To use RAPIDS Accelerator For Apache Spark, XGBoost4j with Spark 3
 
 *   Apache Spark 3.0+
 *   Hardware Requirements
@@ -36,13 +36,13 @@ To use Spark Rapids SQL plugin, XGBoost4j with Spark 3
 
 This section describes how to create
 [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster with
-[Spark RAPIDS SQL plugin](https://github.com/NVIDIA/spark-rapids) and
+[RAPIDS Accelerator For Apache Spark](https://github.com/NVIDIA/spark-rapids) and
 [XGBoost4j](https://github.com/NVIDIA/spark-xgboost-examples).
 
-### Step 1. Create Dataproc cluster with Spark RAPIDS Accelerator
+### Step 1. Create Dataproc cluster with RAPIDS Accelerator For Apache Spark
 
 The following command will create a new Dataproc cluster named `CLUSTER_NAME`
-with installed GPU drivers, Spark RAPIDS Accelerator, Spark RAPIDS XGBoost
+with installed GPU drivers, RAPIDS Accelerator For Apache Spark, Spark RAPIDS XGBoost
 libraries and Jupyter Notebook.
 
 A few notes:
@@ -126,7 +126,7 @@ This section describes how to create
 
 ### Prerequisites
 
-To use XGBoost4j with Spark 2
+To use Spark RAPIDS XGBoost4j with Spark 2
 
 *   Apache Spark 2.3+
 *   Hardware Requirements
@@ -321,7 +321,7 @@ gcloud dataproc jobs submit pyspark \
     host-memory for buffering data to and from GPUs. When running with a single
     attached GPU, GCP only permits machine types up to 24 vCPUs.
 
-## Dask RAPIDS
+## RAPIDS Accelerator For Dask
 
 This section automates the process of setting up a Dataproc cluster with
 DASK and RAPIDS installed. This requires additionally using the
@@ -353,7 +353,7 @@ gcloud dataproc clusters create $CLUSTER_NAME \
     --enable-component-gateway
 ```
 
-### Run Dask RAPIDS workload
+### Run RAPIDS Accelerator For Dask workload
 
 Once the cluster has been created, if using `standalone` mode, the Dask
 scheduler listens for workers on port `8786`, and its status dashboard is on
@@ -431,7 +431,7 @@ gcloud dataproc clusters create $CLUSTER_NAME \
 *   RAPIDS initialization action depends on the
     [Anaconda](https://cloud.google.com/dataproc/docs/concepts/components/anaconda)
     component, which should be included at cluster creation time via the
-    `--optional-components=ANACONDA` argument.
+    `--optional-components=ANACONDA` argument. - this is no longer needed for Dataproc 2.0
 *   RAPIDS initialization action depends on the [GPU](/gpu/README.md)
     initialization action, which should be included at cluster creation time via
     the `--initialization-actions

--- a/rapids/README.md
+++ b/rapids/README.md
@@ -113,6 +113,8 @@ out.explain()
 
 From `out.explain()`, you should see `GpuRowToColumn`, `GpuFilter`,
 `GpuColumnarExchange`, those all indicate things that would run on the GPU.
+In some releases, you might not see that due to AQE has not finalized the plan. Please see
+[RAPIDS Spark Q&A for more details](https://nvidia.github.io/spark-rapids/docs/FAQ.html#is-adaptive-query-execution-aqe-supported)
 
 Or go to the Spark UI and click on the application you ran and on the "SQL" tab.
 If you click the operation "count at ...", you should see the graph of Spark

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -118,8 +118,10 @@ function configure_spark() {
     cat >>${SPARK_CONF_DIR}/spark-defaults.conf <<EOF
 
 ###### BEGIN : RAPIDS properties for Spark ${SPARK_VERSION} ######
-# turn off aqe to avoid confusion, user can turn it on to work with GPU, but explain output won't show GPU operator
-spark.sql.adaptive.enabled=false
+# Rapids Accelerator for Spark can utilize AQE, but when plan is not finalized, 
+# query explain output won't show GPU operator, if user have doubt
+# they can uncomment the line before to see the GPU plan explan, but AQE on give user the best performance.
+# spark.sql.adaptive.enabled=false
 spark.rapids.sql.concurrentGpuTasks=2
 spark.executor.resource.gpu.amount=1
 spark.executor.cores=2

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -19,7 +19,7 @@ if [[ "${SPARK_VERSION_ENV}" == "3"* ]]; then
   readonly DEFAULT_CUDF_VERSION="0.18.1"
   readonly DEFAULT_XGBOOST_VERSION="1.3.0"
   readonly DEFAULT_XGBOOST_GPU_SUB_VERSION="0.1.0"
-  # TODO: uncomment when Spark 3.1 jars will be released.
+  # TODO: uncomment when Spark 3.1 jars will be released - RAPIDS work with Spark 3.1, this is just for Maven URL
   # readonly SPARK_VERSION="${SPARK_VERSION_ENV}"
   readonly SPARK_VERSION="3.0"
 else

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -118,6 +118,8 @@ function configure_spark() {
     cat >>${SPARK_CONF_DIR}/spark-defaults.conf <<EOF
 
 ###### BEGIN : RAPIDS properties for Spark ${SPARK_VERSION} ######
+# turn off aqe to avoid confusion, user can turn it on to work with GPU, but explain output won't show GPU operator
+spark.sql.adaptive.enabled=false
 spark.rapids.sql.concurrentGpuTasks=2
 spark.executor.resource.gpu.amount=1
 spark.executor.cores=2

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -8,6 +8,9 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
+readonly DEFAULT_RAPIDS_VERSION="0.18"
+readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_RAPIDS_VERSION})
+
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
 readonly DEFAULT_SPARK_RAPIDS_VERSION="0.4.0"
 
@@ -36,17 +39,6 @@ readonly RUN_WORKER_ON_MASTER=$(get_metadata_attribute 'dask-cuda-worker-on-mast
 # RAPIDS config
 readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
 readonly CUDF_VERSION=$(get_metadata_attribute 'cudf-version' ${DEFAULT_CUDF_VERSION})
-
-# TODO: standardize versions when Spark 3.1 jars will be released. 
-if [[ "${RUNTIME}" == "DASK" ]]; then
-  DEFAULT_RAPIDS_VERSION="0.18"
-elif [[ "${RUNTIME}" == "SPARK" ]]; then
-  DEFAULT_RAPIDS_VERSION="0.17"
-else
-  echo "Unsupported RAPIDS Runtime: ${RUNTIME}"
-  exit 1
-fi
-readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_RAPIDS_VERSION})
 
 # SPARK config
 readonly SPARK_RAPIDS_VERSION=$(get_metadata_attribute 'spark-rapids-version' ${DEFAULT_SPARK_RAPIDS_VERSION})

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -9,11 +9,11 @@ function get_metadata_attribute() {
 }
 
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
-readonly DEFAULT_SPARK_RAPIDS_VERSION="0.3.0"
+readonly DEFAULT_SPARK_RAPIDS_VERSION="0.4.0"
 
 if [[ "${SPARK_VERSION_ENV}" == "3"* ]]; then
   readonly DEFAULT_CUDA_VERSION="10.2"
-  readonly DEFAULT_CUDF_VERSION="0.18"
+  readonly DEFAULT_CUDF_VERSION="0.18.1"
   readonly DEFAULT_XGBOOST_VERSION="1.3.0"
   readonly DEFAULT_XGBOOST_GPU_SUB_VERSION="0.1.0"
   # TODO: uncomment when Spark 3.1 jars will be released.


### PR DESCRIPTION
Update init script to use RAPIDS Spark v0.4.0
Note that cudf version is 0.18.1 to include a hot fix, this doesn't impact RAPIDS Dask
Also use NVIDIA provided driver as default as it works better with Tesla GPUs that is in GCP

@sameerz @viadea for Viz

Release note could be found here: https://nvidia.github.io/spark-rapids/docs/download.html#release-v040

New features:
```
* Decimal support up to 64 bit, including reading and writing decimal from Parquet (can be enabled by setting spark.rapids.sql.decimalType.enabled to True)
* Ability for users to provide GPU versions of Scala, Java or Hive UDFs
* Shuffle and sort support for struct data types
* array_contains for list operations
* collect_list and average for windowing operations
* Murmur3 hash operation
* Improved performance when reading from DataSource v2 when the source produces data in the Arrow format
```
@bradmiro @medb hope we can merge this asap for some joint customer POCs.