### PR TITLE
[livy] Create home dir for livy user

### DIFF
--- a/livy/livy.sh
+++ b/livy/livy.sh
@@ -90,8 +90,10 @@ function main() {
   ln -s "/usr/local/lib/${LIVY_PKG_NAME}" "${LIVY_DIR}"
 
   # Create Livy user.
-  useradd -G hadoop livy
-
+  useradd -G hadoop livy -d /home/livy
+  mkdir -p /home/livy
+  chown livy:hadoop /home/livy
+  
   # Setup livy package.
   chown -R -L livy:livy "${LIVY_DIR}"
 


### PR DESCRIPTION
Current instructions do not create home for **livy** user.
It can create problems under some circumstances; for examples when $HOME/.cache/Python-Eggs is being created when dealing with python eggs.

