### PR TITLE
Upgrade rapids for spark to 0.4.1 from 0.4.0

### DIFF
--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -12,7 +12,7 @@ readonly DEFAULT_RAPIDS_VERSION="0.18"
 readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_RAPIDS_VERSION})
 
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
-readonly DEFAULT_SPARK_RAPIDS_VERSION="0.4.0"
+readonly DEFAULT_SPARK_RAPIDS_VERSION="0.4.1"
 
 if [[ "${SPARK_VERSION_ENV}" == "3"* ]]; then
   readonly DEFAULT_CUDA_VERSION="10.2"


### PR DESCRIPTION
Upgrade the version of  RAPIDS Accelerator for Apache Spark to 0.4.1 from 0.4.0