### PR TITLE
Check new marker files which will be published in new releases

### DIFF
--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -181,8 +181,11 @@ fi
 # to work in the future. Use at your own risk!
 restart_dataproc_agent() {
   # Because Dataproc Agent should be restarted after initialization, we need to wait until
-  # it will create a sentinel file that signals initialization competition (success or failure)
-  while [[ ! -f /var/lib/google/dataproc/has_run_before ]]; do
+  # it will create a sentinel file that signals initialization competition (success or failure).
+  # NOTE: has_run_before will no longer be published by upcoming image releases
+  while [[ !(-f /var/lib/google/dataproc/has_run_before \
+    || -f /var/lib/google/dataproc/has_succeeded_before \
+    || -f /var/lib/google/dataproc/has_failed_before)]]; do
     sleep 1
   done
   # If Dataproc Agent didn't create a sentinel file that signals initialization


### PR DESCRIPTION
Agent in new releases will not longer be publishing redundant has_run_before flag. We do still need it here for backward compatibility for old images.

Ran only the test_connectors.py which passes.

```
deependrap@deependrap:~/initialization-actions$ bazel test :DataprocInitActionsTestSuite --test_arg=--image_version=2.0 --jobs=25
INFO: Build option --test_arg has changed, discarding analysis cache.
INFO: Analyzed target //connectors:test_connectors (0 packages loaded, 354 targets configured).
INFO: Found 1 test target...
Target //connectors:test_connectors up-to-date:
  bazel-bin/connectors/test_connectors
INFO: Elapsed time: 509.349s, Critical Path: 508.95s
INFO: 11 processes: 1 internal, 10 local.
INFO: Build completed successfully, 11 total actions
//connectors:test_connectors                                             PASSED in 508.9s
  Stats over 10 runs: max = 508.9s, min = 191.1s, avg = 267.0s, dev = 98.2s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 11 total actions

```