### PR TITLE
install rapids+blazingSQL, bump up to 0.19 release

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -32,7 +32,7 @@ ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly ROLE
 
 # CUDA Version
-CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '10.2')
+CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '11.0')
 readonly CUDA_VERSION
 
 # Parameters for NVIDIA-provided Debian GPU driver

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -8,14 +8,14 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-readonly DEFAULT_RAPIDS_VERSION="0.18"
+readonly DEFAULT_RAPIDS_VERSION="0.19"
 readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_RAPIDS_VERSION})
 
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
 readonly DEFAULT_SPARK_RAPIDS_VERSION="0.4.1"
 
 if [[ "${SPARK_VERSION_ENV}" == "3"* ]]; then
-  readonly DEFAULT_CUDA_VERSION="10.2"
+  readonly DEFAULT_CUDA_VERSION="11.0"
   readonly DEFAULT_CUDF_VERSION="0.18.1"
   readonly DEFAULT_XGBOOST_VERSION="1.3.0"
   readonly DEFAULT_XGBOOST_GPU_SUB_VERSION="0.1.0"
@@ -77,7 +77,7 @@ function install_dask_rapids() {
   # Dependency "icu" is also reinstalled here. 
   ${base}/envs/${mamba_env}/bin/mamba install -y \
     -c "rapidsai" -c "nvidia" -c "conda-forge" -c "defaults" \
-    "cudatoolkit=${CUDA_VERSION}" "rapids=${RAPIDS_VERSION}" \
+    "cudatoolkit=${CUDA_VERSION}" "rapids-blazing=${RAPIDS_VERSION}" \
     -p ${base}
 
   # Remove mamba env


### PR DESCRIPTION
According to https://rapids.ai/start.html, the default rapids conda install should include blazingSQL, also bump up default cuda to cuda 11, cuda 10.x EOL after RAPIDS 0.19.