### PR TITLE
Updating upstream url for toree artifact

### DIFF
--- a/jupyter/kernels/install-toree.sh
+++ b/jupyter/kernels/install-toree.sh
@@ -6,10 +6,10 @@
 
 set -e
 
-REPO_URL="https://dist.apache.org/repos/dist"
+REPO_URL="https://archive.apache.org/dist"
 /opt/conda/bin/pip \
   install \
-  ${REPO_URL}/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
+  ${REPO_URL}/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
 
 SPARK_MAJOR_VERSION=$(spark-submit --version |&
   grep 'version' | head -n 1 | sed 's/.*version //' | cut -d '.' -f 1)


### PR DESCRIPTION
Fix for https://github.com/GoogleCloudDataproc/initialization-actions/issues/906.

Currently jupyter init action fails as downloading toree artifact 0.2.0-incubating fails. Changing remote url to apache archive.