### PR TITLE
Add ldconfig after gpu driver installation completes.

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.3-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.3 Ubuntu image
@@ -28,7 +28,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.3-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.4 Debian image
@@ -39,7 +39,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.4-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.4 Ubuntu image
@@ -50,7 +50,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.4-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.5 CentOS image
@@ -61,7 +61,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-centos8']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.5 Debian image
@@ -72,7 +72,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.5 Ubuntu image
@@ -83,7 +83,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 2.0 Debian image
@@ -94,7 +94,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '2.0-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 2.0 Ubuntu image
@@ -105,7 +105,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '2.0-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Delete Docker image from GCR

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.3-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.3 Ubuntu image
@@ -28,7 +28,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.3-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.4 Debian image
@@ -39,7 +39,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.4-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.4 Ubuntu image
@@ -50,7 +50,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.4-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.5 CentOS image
@@ -61,7 +61,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-centos8']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.5 Debian image
@@ -72,7 +72,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 1.5 Ubuntu image
@@ -83,7 +83,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '1.5-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 2.0 Debian image
@@ -94,7 +94,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '2.0-debian10']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Run presubmit tests in parallel for 2.0 Ubuntu image
@@ -105,7 +105,7 @@ steps:
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID', '2.0-ubuntu18']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
-      - 'CLOUDSDK_COMPUTE_REGION=us-central1'
+      - 'CLOUDSDK_COMPUTE_REGION=us-west1'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 
   # Delete Docker image from GCR

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -1,9 +1,9 @@
 # GPU driver installation
 
 GPUs require special drivers and software which are not pre-installed on
-[Cloud Dataproc](https://cloud.google.com/dataproc) clusters by default.
+[Dataproc](https://cloud.google.com/dataproc) clusters by default.
 This initialization action installs GPU driver for NVIDIA GPUs on master and
-worker nodes in a Cloud Dataproc cluster.
+worker nodes in a Dataproc cluster.
 
 **Note:** This feature is in Beta mode.
 
@@ -17,13 +17,8 @@ You can use this initialization action to create a new Dataproc cluster with GPU
 support - it will install NVIDIA GPU drivers and CUDA on cluster nodes with
 attached GPU adapters.
 
-This initialization action supports installation of OS-provided and
-NVIDIA-provided GPU drivers and CUDA. By default, this initialization action
-installs OS-provided GPU drivers and CUDA, to choose provider use `--metadata
-gpu-driver-provider=<OS|NVIDIA>` metadata value.
-
-1.  Use the `gcloud` command to create a new cluster with OS-provided GPU driver
-    and CUDA installed by initialization action.
+1.  Use the `gcloud` command to create a new cluster with NVIDIA-provided GPU
+    drivers and CUDA installed by initialization action.
 
     ```bash
     REGION=<region>
@@ -35,22 +30,8 @@ gpu-driver-provider=<OS|NVIDIA>` metadata value.
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh
     ```
 
-1.  Use the `gcloud` command to create a new cluster with NVIDIA-provided GPU
-    driver and CUDA installed by initialization action.
-
-    ```bash
-    REGION=<region>
-    CLUSTER_NAME=<cluster_name>
-    gcloud dataproc clusters create ${CLUSTER_NAME} \
-        --region ${REGION} \
-        --master-accelerator type=nvidia-tesla-v100 \
-        --worker-accelerator type=nvidia-tesla-v100,count=4 \
-        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh \
-        --metadata gpu-driver-provider=NVIDIA
-    ```
-
-1.  Use the `gcloud` command to create a new cluster with OS-provided GPU driver
-    and CUDA installed by initialization action. Additionally, it installs GPU
+1.  Use the `gcloud` command to create a new cluster with NVIDIA GPU drivers
+    and CUDA installed by initialization action as well as the GPU
     monitoring service. The monitoring service is supported on Dataproc 1.4+ images.
 
     *Prerequisite:* Create GPU metrics in
@@ -136,9 +117,6 @@ sometimes found in the "building from source" sections.
     **Note:** This parameter will collect GPU utilization and send statistics to
     Stackdriver. Make sure you add the correct scope to access Stackdriver.
 
--   `gpu-driver-provider: OS|NVIDIA` - this is an optional parameter with
-    case-sensitive value. Default is `OS`.
-
 -   `gpu-driver-url: <URL>` - this is an optional parameter for customizing
     NVIDIA-provided GPU driver on Debian.
 
@@ -200,5 +178,3 @@ sudo systemctl status gpu-utilization-agent.service
 
 *   This initialization script will install NVIDIA GPU drivers in all nodes in
     which a GPU is detected.
-*   This initialization script can use OS-provided (Debian or Ubuntu) or
-    NVIDIA-provided packages to install GPU drivers and CUDA.

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -200,7 +200,7 @@ function install_nvidia_gpu_driver() {
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
-
+  ldconfig
   echo "NVIDIA GPU driver provided by NVIDIA was installed successfully"
 }
 

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -24,7 +24,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   @parameterized.parameters(
       ("SINGLE", ["m"], GPU_V100, None, None),
       ("STANDARD", ["m"], GPU_V100, None, None),
-      ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "OS"),
+      ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "NVIDIA"),
       ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "NVIDIA"),
   )
   def test_install_gpu_default_agent(self, configuration, machine_suffixes,
@@ -50,7 +50,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
       ("STANDARD", ["w-0", "w-1"], None, GPU_V100, None),
-      ("STANDARD", ["m"], GPU_V100, None, "OS"),
+      ("STANDARD", ["m"], GPU_V100, None, "NVIDIA"),
       ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "NVIDIA"),
   )
   def test_install_gpu_without_agent(self, configuration, machine_suffixes,
@@ -76,7 +76,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
       ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, None),
-      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "OS"),
+      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "NVIDIA"),
       ("STANDARD", ["m"], GPU_V100, None, "NVIDIA"),
   )
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,

--- a/jupyter/kernels/install-toree.sh
+++ b/jupyter/kernels/install-toree.sh
@@ -6,10 +6,10 @@
 
 set -e
 
-REPO_URL="https://dist.apache.org/repos/dist"
+REPO_URL="https://archive.apache.org/dist"
 /opt/conda/bin/pip \
   install \
-  ${REPO_URL}/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
+  ${REPO_URL}/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
 
 SPARK_MAJOR_VERSION=$(spark-submit --version |&
   grep 'version' | head -n 1 | sed 's/.*version //' | cut -d '.' -f 1)

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -80,12 +80,6 @@ class RapidsTestCase(DataprocTestCase):
     ("SINGLE", ["m"], GPU_P100),
     ("STANDARD", ["w-0"], GPU_P100))
   def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
-    if self.getImageOs() == 'centos':
-      self.skipTest("Not supported in CentOS-based images")
-      
-    if self.getImageOs() == 'debian':
-      self.skipTest("Not supported in Debian-based images")
-
     if self.getImageVersion() <= pkg_resources.parse_version("1.4"):
       self.skipTest("Not supported in pre 1.5 images")
 

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -80,6 +80,9 @@ class RapidsTestCase(DataprocTestCase):
     ("SINGLE", ["m"], GPU_P100),
     ("STANDARD", ["w-0"], GPU_P100))
   def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
+    if self.getImageOs() == 'centos':
+      self.skipTest("Not supported in CentOS-based images")
+
     if self.getImageVersion() <= pkg_resources.parse_version("1.4"):
       self.skipTest("Not supported in pre 1.5 images")
 


### PR DESCRIPTION
We should add ldconfig after GPU driver installation otherwise it triggered the issue in https://github.com/GoogleCloudDataproc/initialization-actions/pull/907.

After adding ldconfig, the debian image works fine for spark-rapids as per my tests.