### PR TITLE
[GPU]Create CentOS gpu installation init action, clean up os driver install to avoid test failure, pin driver to 460.

### DIFF
--- a/gpu/README.md
+++ b/gpu/README.md
@@ -1,9 +1,9 @@
 # GPU driver installation
 
 GPUs require special drivers and software which are not pre-installed on
-[Cloud Dataproc](https://cloud.google.com/dataproc) clusters by default.
+[Dataproc](https://cloud.google.com/dataproc) clusters by default.
 This initialization action installs GPU driver for NVIDIA GPUs on master and
-worker nodes in a Cloud Dataproc cluster.
+worker nodes in a Dataproc cluster.
 
 **Note:** This feature is in Beta mode.
 
@@ -17,13 +17,8 @@ You can use this initialization action to create a new Dataproc cluster with GPU
 support - it will install NVIDIA GPU drivers and CUDA on cluster nodes with
 attached GPU adapters.
 
-This initialization action supports installation of OS-provided and
-NVIDIA-provided GPU drivers and CUDA. By default, this initialization action
-installs OS-provided GPU drivers and CUDA, to choose provider use `--metadata
-gpu-driver-provider=<OS|NVIDIA>` metadata value.
-
-1.  Use the `gcloud` command to create a new cluster with OS-provided GPU driver
-    and CUDA installed by initialization action.
+1.  Use the `gcloud` command to create a new cluster with NVIDIA-provided GPU
+    drivers and CUDA installed by initialization action.
 
     ```bash
     REGION=<region>
@@ -35,22 +30,8 @@ gpu-driver-provider=<OS|NVIDIA>` metadata value.
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh
     ```
 
-1.  Use the `gcloud` command to create a new cluster with NVIDIA-provided GPU
-    driver and CUDA installed by initialization action.
-
-    ```bash
-    REGION=<region>
-    CLUSTER_NAME=<cluster_name>
-    gcloud dataproc clusters create ${CLUSTER_NAME} \
-        --region ${REGION} \
-        --master-accelerator type=nvidia-tesla-v100 \
-        --worker-accelerator type=nvidia-tesla-v100,count=4 \
-        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh \
-        --metadata gpu-driver-provider=NVIDIA
-    ```
-
-1.  Use the `gcloud` command to create a new cluster with OS-provided GPU driver
-    and CUDA installed by initialization action. Additionally, it installs GPU
+1.  Use the `gcloud` command to create a new cluster with NVIDIA GPU drivers
+    and CUDA installed by initialization action as well as the GPU
     monitoring service. The monitoring service is supported on Dataproc 1.4+ images.
 
     *Prerequisite:* Create GPU metrics in
@@ -136,9 +117,6 @@ sometimes found in the "building from source" sections.
     **Note:** This parameter will collect GPU utilization and send statistics to
     Stackdriver. Make sure you add the correct scope to access Stackdriver.
 
--   `gpu-driver-provider: OS|NVIDIA` - this is an optional parameter with
-    case-sensitive value. Default is `OS`.
-
 -   `gpu-driver-url: <URL>` - this is an optional parameter for customizing
     NVIDIA-provided GPU driver on Debian.
 
@@ -200,5 +178,3 @@ sudo systemctl status gpu-utilization-agent.service
 
 *   This initialization script will install NVIDIA GPU drivers in all nodes in
     which a GPU is detected.
-*   This initialization script can use OS-provided (Debian or Ubuntu) or
-    NVIDIA-provided packages to install GPU drivers and CUDA.

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -36,7 +36,7 @@ CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '11.0')
 readonly CUDA_VERSION
 
 # Parameters for NVIDIA-provided Debian GPU driver
-readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='465.31'
+readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.56'
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
 NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL
@@ -115,7 +115,7 @@ function install_nvidia_nccl() {
 
     execute_with_retries \
       "apt-get install -y --allow-unauthenticated libnccl2=${nccl_version} libnccl-dev=${nccl_version}"
-  else 
+  else
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
@@ -133,7 +133,7 @@ function install_nvidia_cudnn() {
     else
       echo "Unsupported CUDNN version: '${CUDNN_VERSION}'"
       exit 1
-    fi      
+    fi
   elif [[ ${OS_NAME} == ubuntu ]]; then
     local -a packages
     packages=(
@@ -193,7 +193,7 @@ function install_nvidia_gpu_driver() {
     execute_with_retries "dnf clean all"
     execute_with_retries "dnf -y -q module install nvidia-driver:460-dkms"
     execute_with_retries "dnf -y -q install cuda-${CUDA_VERSION//./-}"
-  else 
+  else
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
@@ -390,7 +390,7 @@ function main() {
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
-  
+
   if [[ ${OS_NAME} == debian ]] || [[ ${OS_NAME} == ubuntu ]]; then
     export DEBIAN_FRONTEND=noninteractive
     execute_with_retries "apt-get update"
@@ -400,7 +400,7 @@ function main() {
     execute_with_retries "dnf -y -q install pciutils"
     execute_with_retries "dnf -y -q install kernel-devel"
     execute_with_retries "dnf -y -q install gcc"
-  fi 
+  fi
 
   # This configuration should be ran on all nodes
   # regardless if they have attached GPUs
@@ -410,7 +410,7 @@ function main() {
   if (lspci | grep -q NVIDIA); then
     configure_yarn_nodemanager
     configure_gpu_isolation
-    
+
     if [[ ${OS_NAME} == debian ]] || [[ ${OS_NAME} == ubuntu ]]; then
       execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
     fi

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -24,8 +24,6 @@ function get_metadata_attribute() {
 
 OS_NAME=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
 readonly OS_NAME
-OS_DIST=$(lsb_release -cs)
-readonly OS_DIST
 
 # Dataproc role
 ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
@@ -347,7 +345,6 @@ function main() {
     if [[ ${OS_NAME} == debian ]] || [[ ${OS_NAME} == ubuntu ]]; then
       execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
     fi
-
 
     install_nvidia_gpu_driver
     if [[ -n ${CUDNN_VERSION} ]]; then

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -32,7 +32,7 @@ ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly ROLE
 
 # Parameters for NVIDIA-provided Debian GPU driver
-readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.56'
+readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.73.01'
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
 NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL
@@ -186,11 +186,12 @@ function install_nvidia_gpu_driver() {
     execute_with_retries "apt-get update"
 
     if [[ -n "${CUDA_VERSION}" ]]; then
-      local -r cuda_package=cuda-${CUDA_VERSION//./-}
+      local -r cuda_package=cuda-toolkit-${CUDA_VERSION//./-}
     else
-      local -r cuda_package=cuda
+      local -r cuda_package=cuda-toolkit
     fi
     # Without --no-install-recommends this takes a very long time.
+    execute_with_retries "apt-get install -y -q --no-install-recommends cuda-drivers-460"
     execute_with_retries "apt-get install -y -q --no-install-recommends ${cuda_package}"
   elif [[ ${OS_NAME} == centos ]]; then
     execute_with_retries "dnf config-manager --add-repo ${NVIDIA_CENTOS_REPOSITORY_URL}"

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -32,7 +32,7 @@ ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly ROLE
 
 # Parameters for NVIDIA-provided Debian GPU driver
-readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.73.01'
+readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.56'
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
 NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -31,10 +31,6 @@ readonly OS_DIST
 ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly ROLE
 
-# CUDA Version
-CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '11.0')
-readonly CUDA_VERSION
-
 # Parameters for NVIDIA-provided Debian GPU driver
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.56'
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
@@ -42,6 +38,21 @@ NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAUL
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL
 
 readonly NVIDIA_BASE_DL_URL='https://developer.download.nvidia.com/compute'
+
+# CUDA Version
+CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '11.0')
+readonly CUDA_VERSION
+
+# Parameters for NVIDIA-provided NCCL library
+readonly DEFAULT_NCCL_REPO_URL="${NVIDIA_BASE_DL_URL}/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb"
+NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}")
+readonly NCCL_REPO_URL
+if [[ "$(echo "$DATAPROC_VERSION >= 2.0" | bc)" -eq 1 ]]; then
+  NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.8.4')
+else
+  NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.7.8')
+fi
+readonly NCCL_VERSION
 
 readonly -A DEFAULT_NVIDIA_DEBIAN_CUDA_URLS=(
   [10.1]="${NVIDIA_BASE_DL_URL}/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run"
@@ -59,13 +70,6 @@ readonly NVIDIA_UBUNTU_REPOSITORY_CUDA_PIN="${NVIDIA_UBUNTU_REPOSITORY_URL}/cuda
 
 # Parameter for NVIDIA-provided Centos GPU driver
 readonly NVIDIA_CENTOS_REPOSITORY_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/rhel8/x86_64/cuda-rhel8.repo"
-
-# Parameters for NVIDIA-provided NCCL library
-readonly DEFAULT_NCCL_REPO_URL="${NVIDIA_BASE_DL_URL}/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb"
-NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}")
-readonly NCCL_REPO_URL
-NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.8.4')
-readonly NCCL_VERSION
 
 # Parameters for NVIDIA-provided CUDNN library
 readonly CUDNN_VERSION=$(get_metadata_attribute 'cudnn-version' '')

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -32,7 +32,7 @@ ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly ROLE
 
 # Parameters for NVIDIA-provided Debian GPU driver
-readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.56'
+readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.73.01'
 readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
 NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -36,8 +36,8 @@ CUDA_VERSION=$(get_metadata_attribute 'cuda-version' '11.0')
 readonly CUDA_VERSION
 
 # Parameters for NVIDIA-provided Debian GPU driver
-readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='460.56'
-readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://us.download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
+readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION='465.31'
+readonly DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_VERSION}.run"
 NVIDIA_DEBIAN_GPU_DRIVER_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_NVIDIA_DEBIAN_GPU_DRIVER_URL}")
 readonly NVIDIA_DEBIAN_GPU_DRIVER_URL
 
@@ -57,11 +57,14 @@ readonly NVIDIA_UBUNTU_REPOSITORY_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/ubuntu18
 readonly NVIDIA_UBUNTU_REPOSITORY_KEY="${NVIDIA_UBUNTU_REPOSITORY_URL}/7fa2af80.pub"
 readonly NVIDIA_UBUNTU_REPOSITORY_CUDA_PIN="${NVIDIA_UBUNTU_REPOSITORY_URL}/cuda-ubuntu1804.pin"
 
+# Parameter for NVIDIA-provided Centos GPU driver
+readonly NVIDIA_CENTOS_REPOSITORY_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/rhel8/x86_64/cuda-rhel8.repo"
+
 # Parameters for NVIDIA-provided NCCL library
 readonly DEFAULT_NCCL_REPO_URL="${NVIDIA_BASE_DL_URL}/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb"
 NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}")
 readonly NCCL_REPO_URL
-NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.7.8')
+NCCL_VERSION=$(get_metadata_attribute 'nccl-version' '2.8.4')
 readonly NCCL_VERSION
 
 # Parameters for NVIDIA-provided CUDNN library
@@ -96,26 +99,42 @@ function execute_with_retries() {
 }
 
 function install_nvidia_nccl() {
-  local tmp_dir
-  tmp_dir=$(mktemp -d -t gpu-init-action-nccl-XXXX)
-
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
-    "${NCCL_REPO_URL}" -o "${tmp_dir}/nvidia-ml-repo.deb"
-  dpkg -i "${tmp_dir}/nvidia-ml-repo.deb"
-
-  execute_with_retries "apt-get update"
-
   local -r nccl_version="${NCCL_VERSION}-1+cuda${CUDA_VERSION}"
-  execute_with_retries \
-    "apt-get install -y --allow-unauthenticated libnccl2=${nccl_version} libnccl-dev=${nccl_version}"
+
+  if [[ ${OS_NAME} == centos ]]; then
+    execute_with_retries "dnf -y -q install libnccl-${nccl_version} libnccl-devel-${nccl_version} libnccl-static-${nccl_version}"
+  elif [[ ${OS_NAME} == ubuntu ]] || [[ ${OS_NAME} == debian ]]; then
+    local tmp_dir
+    tmp_dir=$(mktemp -d -t gpu-init-action-nccl-XXXX)
+
+    curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+      "${NCCL_REPO_URL}" -o "${tmp_dir}/nvidia-ml-repo.deb"
+    dpkg -i "${tmp_dir}/nvidia-ml-repo.deb"
+
+    execute_with_retries "apt-get update"
+
+    execute_with_retries \
+      "apt-get install -y --allow-unauthenticated libnccl2=${nccl_version} libnccl-dev=${nccl_version}"
+  else 
+    echo "Unsupported OS: '${OS_NAME}'"
+    exit 1
+  fi
 }
 
 function install_nvidia_cudnn() {
-  if [[ ${OS_NAME} == ubuntu ]]; then
-    local major_version
-    major_version="${CUDNN_VERSION%%.*}"
-    local cudnn_pkg_version
-    cudnn_pkg_version="${CUDNN_VERSION}-1+cuda${CUDA_VERSION}"
+  local major_version
+  major_version="${CUDNN_VERSION%%.*}"
+  local cudnn_pkg_version
+  cudnn_pkg_version="${CUDNN_VERSION}-1+cuda${CUDA_VERSION}"
+
+  if [[ ${OS_NAME} == centos ]]; then
+    if [[ ${major_version} == 8 ]]; then
+      execute_with_retries "dnf -y -q install libcudnn8-${cudnn_pkg_version} libcudnn8-devel-${cudnn_pkg_version}"
+    else
+      echo "Unsupported CUDNN version: '${CUDNN_VERSION}'"
+      exit 1
+    fi      
+  elif [[ ${OS_NAME} == ubuntu ]]; then
     local -a packages
     packages=(
       "libcudnn${major_version}=${cudnn_pkg_version}"
@@ -143,9 +162,9 @@ EOF
 
 # Install NVIDIA GPU driver provided by NVIDIA
 function install_nvidia_gpu_driver() {
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
-    "${NVIDIA_UBUNTU_REPOSITORY_KEY}" | apt-key add -
   if [[ ${OS_NAME} == debian ]]; then
+    curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+    "${NVIDIA_UBUNTU_REPOSITORY_KEY}" | apt-key add -
     curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
       "${NVIDIA_DEBIAN_GPU_DRIVER_URL}" -o driver.run
     bash "./driver.run" --silent --install-libglvnd
@@ -154,6 +173,8 @@ function install_nvidia_gpu_driver() {
       "${NVIDIA_DEBIAN_CUDA_URL}" -o cuda.run
     bash "./cuda.run" --silent --toolkit --no-opengl-libs
   elif [[ ${OS_NAME} == ubuntu ]]; then
+    curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+    "${NVIDIA_UBUNTU_REPOSITORY_KEY}" | apt-key add -
     curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
       "${NVIDIA_UBUNTU_REPOSITORY_CUDA_PIN}" -o /etc/apt/preferences.d/cuda-repository-pin-600
 
@@ -167,7 +188,12 @@ function install_nvidia_gpu_driver() {
     fi
     # Without --no-install-recommends this takes a very long time.
     execute_with_retries "apt-get install -y -q --no-install-recommends ${cuda_package}"
-  else
+  elif [[ ${OS_NAME} == centos ]]; then
+    execute_with_retries "dnf config-manager --add-repo ${NVIDIA_CENTOS_REPOSITORY_URL}"
+    execute_with_retries "dnf clean all"
+    execute_with_retries "dnf -y -q module install nvidia-driver:460-dkms"
+    execute_with_retries "dnf -y -q install cuda-${CUDA_VERSION//./-}"
+  else 
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
@@ -360,14 +386,21 @@ function configure_gpu_isolation() {
 }
 
 function main() {
-  if [[ ${OS_NAME} != debian ]] && [[ ${OS_NAME} != ubuntu ]]; then
+  if [[ ${OS_NAME} != debian ]] && [[ ${OS_NAME} != ubuntu ]] && [[ ${OS_NAME} != centos ]]; then
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
-
-  export DEBIAN_FRONTEND=noninteractive
-  execute_with_retries "apt-get update"
-  execute_with_retries "apt-get install -y -q pciutils"
+  
+  if [[ ${OS_NAME} == debian ]] || [[ ${OS_NAME} == ubuntu ]]; then
+    export DEBIAN_FRONTEND=noninteractive
+    execute_with_retries "apt-get update"
+    execute_with_retries "apt-get install -y -q pciutils"
+  elif [[ ${OS_NAME} == centos ]] ; then
+    execute_with_retries "dnf -y -q update"
+    execute_with_retries "dnf -y -q install pciutils"
+    execute_with_retries "dnf -y -q install kernel-devel"
+    execute_with_retries "dnf -y -q install gcc"
+  fi 
 
   # This configuration should be ran on all nodes
   # regardless if they have attached GPUs
@@ -377,8 +410,10 @@ function main() {
   if (lspci | grep -q NVIDIA); then
     configure_yarn_nodemanager
     configure_gpu_isolation
-
-    execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
+    
+    if [[ ${OS_NAME} == debian ]] || [[ ${OS_NAME} == ubuntu ]]; then
+      execute_with_retries "apt-get install -y -q 'linux-headers-$(uname -r)'"
+    fi
 
     if [[ ${GPU_DRIVER_PROVIDER} == 'NVIDIA' ]]; then
       install_nvidia_gpu_driver

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -24,7 +24,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   @parameterized.parameters(
       ("SINGLE", ["m"], GPU_V100, None, None),
       ("STANDARD", ["m"], GPU_V100, None, None),
-      ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "OS"),
+      ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "NVIDIA"),
       ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "NVIDIA"),
   )
   def test_install_gpu_default_agent(self, configuration, machine_suffixes,
@@ -50,7 +50,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
       ("STANDARD", ["w-0", "w-1"], None, GPU_V100, None),
-      ("STANDARD", ["m"], GPU_V100, None, "OS"),
+      ("STANDARD", ["m"], GPU_V100, None, "NVIDIA"),
       ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, "NVIDIA"),
   )
   def test_install_gpu_without_agent(self, configuration, machine_suffixes,
@@ -76,7 +76,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
       ("STANDARD", ["m", "w-0", "w-1"], GPU_V100, GPU_V100, None),
-      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "OS"),
+      ("STANDARD", ["w-0", "w-1"], None, GPU_V100, "NVIDIA"),
       ("STANDARD", ["m"], GPU_V100, None, "NVIDIA"),
   )
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,


### PR DESCRIPTION
per https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions#centos_images, dataproc 2.0 support centos images, this pull request add gpu libraries installation for centos8 which dataproc 2.0 supports.

BTW, the installation is so slow, I have to use `--initialization-action-timeout=60m`

@bradmiro @sameerz @viadea please review. Thanks