### PR TITLE
[GPU][RAPIDS] fix typo in GPU and support CUDA 11.2 in RAPIDS

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -65,7 +65,7 @@ readonly -A DEFAULT_NVIDIA_DEBIAN_CUDA_URLS=(
   [10.2]="${NVIDIA_BASE_DL_URL}/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run"
   [11.0]="${NVIDIA_BASE_DL_URL}/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run"
   [11.1]="${NVIDIA_BASE_DL_URL}/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run"
-  [11.2]="${NVIDIA_BASE_DL_URL}/cuda/11.2./local_installers/cuda_11.2.2_460.32.03_linux.run")
+  [11.2]="${NVIDIA_BASE_DL_URL}/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run")
 readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL=${DEFAULT_NVIDIA_DEBIAN_CUDA_URLS["${CUDA_VERSION}"]}
 NVIDIA_DEBIAN_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_DEBIAN_CUDA_URL}")
 readonly NVIDIA_DEBIAN_CUDA_URL

--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -74,7 +74,6 @@ function install_dask_rapids() {
   conda create -y -n ${mamba_env} -c conda-forge mamba
 
   # Install RAPIDS, cudatoolkit. Use mamba in new env to resolve base environment
-  # Dependency "icu" is also reinstalled here. 
   ${base}/envs/${mamba_env}/bin/mamba install -y \
     -c "rapidsai" -c "nvidia" -c "conda-forge" -c "defaults" \
     "cudatoolkit=${CUDA_VERSION}" "rapids-blazing=${RAPIDS_VERSION}" \
@@ -88,6 +87,12 @@ function install_spark_rapids() {
   local -r rapids_repo_url='https://repo1.maven.org/maven2/ai/rapids'
   local -r nvidia_repo_url='https://repo1.maven.org/maven2/com/nvidia'
   local cudf_cuda_version="${CUDA_VERSION//\./-}"
+
+  # SPARK RAPIDS for CUDA 11 haven't been released beyond 11.0, so default to 11.0
+  if [[ ${cudf_cuda_version} == 11.* ]]; then
+    cudf_cuda_version="11.0"
+  fi
+
   # Convert "11-0" to "11"
   cudf_cuda_version="${cudf_cuda_version%-0}"
 


### PR DESCRIPTION
* Fixing a typo in the GPU init action
* If CUDA 11 is provided, always downloads RAPIDS SPARK jars for 11.0 (until future JARS are released) in the event that say CUDA 11.1 or 11.2 are supplied.

@mengdong please take a look and confirm that the latter is also safe to do. My understanding of CUDA's backwards compatibility is that this should be fine.