### PR TITLE
[livy] Add configurable Livy session timeout through metadata

### DIFF
--- a/livy/README.md
+++ b/livy/README.md
@@ -35,6 +35,17 @@ Livy installed:
         --metadata livy-version=0.7.0
     ```
 
+1.  To change timeout for Livy session, use `livy-timeout-session` metadata value:
+    
+    ```bash
+    REGION=<region>
+    CLUSTER_NAME=<cluster_name>
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --region ${REGION} \
+        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/livy/livy.sh \
+        --metadata livy-timeout-session='3h'
+    ```
+
 1.  Once the cluster has been created, Livy is configured to run on port `8998`
     on the master node in a Dataproc cluster.
 

--- a/livy/livy.sh
+++ b/livy/livy.sh
@@ -17,6 +17,7 @@ set -euxo pipefail
 readonly LIVY_VERSION=$(/usr/share/google/get_metadata_value attributes/livy-version || echo 0.7.0)
 readonly LIVY_PKG_NAME=apache-livy-${LIVY_VERSION}-incubating-bin
 readonly LIVY_URL=https://archive.apache.org/dist/incubator/livy/${LIVY_VERSION}-incubating/${LIVY_PKG_NAME}.zip
+readonly LIVY_TIMEOUT_SESSION=$(/usr/share/google/get_metadata_value attributes/livy-timeout-session || echo 1h)
 
 readonly LIVY_DIR=/usr/local/lib/livy
 readonly LIVY_BIN=${LIVY_DIR}/bin
@@ -27,6 +28,7 @@ function make_livy_conf() {
   cat <<EOF >"${LIVY_CONF}/livy.conf"
 livy.spark.master = $(grep spark.master /etc/spark/conf/spark-defaults.conf | cut -d= -f2)
 livy.spark.deploy-mode = $(grep spark.submit.deployMode /etc/spark/conf/spark-defaults.conf | cut -d= -f2)
+livy.server.session.timeout=$LIVY_TIMEOUT_SESSION
 EOF
 }
 


### PR DESCRIPTION
Problem:
While doing long running jobs on Dataproc cluster a session is being halted after one hour (default Livy session timeout)

Solution:
Add configurable Livy session timeout by adding timeout value by passing it in _metadata_ values. Default value stays the same (1h)