### PR TITLE
The install_gpu_driver script should restart services for yarn config…

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -378,7 +378,9 @@ function main() {
     fi
 
     configure_gpu_exclusive_mode
-    systemctl restart hadoop-yarn-nodemanager.service
+    if systemctl status hadoop-yarn-nodemanager; then
+      systemctl restart hadoop-yarn-nodemanager.service
+    fi
   elif [[ "${ROLE}" == "Master" ]]; then
     configure_yarn_nodemanager
     configure_gpu_isolation

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -378,9 +378,15 @@ function main() {
     fi
 
     configure_gpu_exclusive_mode
+    systemctl restart hadoop-yarn-nodemanager.service
   elif [[ "${ROLE}" == "Master" ]]; then
     configure_yarn_nodemanager
     configure_gpu_isolation
+    systemctl restart hadoop-yarn-resourcemanager.service
+    # Restart NodeManager on Master as well if this is a single-node-cluster.
+    if systemctl status hadoop-yarn-nodemanager; then
+      systemctl restart hadoop-yarn-nodemanager.service
+    fi
   fi
 }
 


### PR DESCRIPTION
…urations to take effect

The following restart step is needed if the install_gpu_driver.sh script is used in isolation, otherwise Yarn isn't finding the gpu configurations (isolation) that we are setting up here.

@mengdong FYI

Replaces: https://github.com/GoogleCloudDataproc/initialization-actions/pull/975, to see if this re-runs the CLA check since closing and re-opening doesn't look to do that