### PR TITLE
[dask] Fix Dask init action and drop pre-2.0 images support

### DIFF
--- a/dask/README.md
+++ b/dask/README.md
@@ -8,7 +8,7 @@ This initialization action will set up Dask on a
 [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster to run with
 either `yarn` or `standalone`, both taking advantage of
 [Dask Distributed](https://distributed.dask.org/en/latest/). This
-initialization action is supported on **Dataproc image versions 1.5 and newer**.
+initialization action is supported on **Dataproc image versions 2.0 and newer**.
 
 In `yarn` mode, the cluster is configured with
 [Dask-Yarn](https://yarn.dask.org). You can then take advantage of Dataproc's
@@ -40,9 +40,8 @@ CLUSTER_NAME=<cluster-name>
 REGION=<region>
 gcloud dataproc clusters create ${CLUSTER_NAME} \
   --region ${REGION} \
-  --master-machine-type n1-standard-16 \
-  --worker-machine-type n1-highmem-32 \
-  --image-version 2.0 \
+  --master-machine-type e2-standard-16 \
+  --worker-machine-type e2-highmem-32 \
   --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/dask/dask.sh \
   --initialization-action-timeout 20m
 ```
@@ -58,9 +57,8 @@ CLUSTER_NAME=<cluster-name>
 REGION=<region>
 gcloud dataproc clusters create ${CLUSTER_NAME} \
   --region ${REGION} \
-  --master-machine-type n1-standard-16 \
-  --worker-machine-type n1-highmem-32 \
-  --image-version 2.0 \
+  --master-machine-type e2-standard-16 \
+  --worker-machine-type e2-highmem-32 \
   --optional-components JUPYTER \
   --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/dask/dask.sh \
   --initialization-action-timeout 45m \
@@ -108,29 +106,7 @@ data services. More information can be found
 [here](https://docs.dask.org/en/latest/remote-data-services.html).
 
 By default, Dataproc image version 2.0+ comes with `pyarrow`, `gcsfs`,
-`fastparquet` and `fastavro` installed. To install additional libraries, or to
-use these libraries on earlier versions of Dataproc, you can use the pip or
-conda
-[initialization actions](https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/python).
-
-Here's an example of creating a Dataproc 1.5 cluster configured with Dask and
-`gcsfs`.
-
-```bash
-CLUSTER_NAME=<cluster-name>
-REGION=<region>
-gcloud dataproc clusters create ${CLUSTER_NAME} \
-  --region ${REGION} \
-  --master-machine-type n1-standard-16 \
-  --worker-machine-type n1-highmem-32 \
-  --image-version 1.5 \
-  --optional-components ANACONDA,JUPYTER \
-  --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/dask/dask.sh,gs://goog-dataproc-initialization-actions-${REGION}/python/conda-install.sh \
-  --metadata "CONDA_CHANNELS=conda-forge" \
-  --metadata "CONDA_PACKAGES=gcsfs" \
-  --initialization-action-timeout 45m \
-  --enable-component-gateway
-```
+`fastparquet` and `fastavro` installed.
 
 ### Interacting with the cluster
 

--- a/dask/dask.sh
+++ b/dask/dask.sh
@@ -38,7 +38,9 @@ readonly DASK_SERVICE=dask-cluster
 CONDA_PACKAGES=("dask=2022.1.1" "dask-bigquery" "dask-ml")
 
 if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
-  CONDA_PACKAGES+=("dask-yarn=0.9")
+  # Pin `distributed` pacakge version because `dask-yarn` 0.9
+  # is not compatible with `distributed` package 2022.3 and newer
+  CONDA_PACKAGES+=("dask-yarn=0.9", "distributed=2022.2")
   
   # Update protobuf on Dataproc 1.x
   if [ "$(echo "$DATAPROC_VERSION < 2.0" | bc)" -eq 1 ]; then

--- a/dask/dask.sh
+++ b/dask/dask.sh
@@ -40,7 +40,7 @@ CONDA_PACKAGES=("dask=2022.1.1" "dask-bigquery" "dask-ml")
 if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
   # Pin `distributed` pacakge version because `dask-yarn` 0.9
   # is not compatible with `distributed` package 2022.3 and newer
-  CONDA_PACKAGES+=("dask-yarn=0.9", "distributed=2022.2")
+  CONDA_PACKAGES+=("dask-yarn=0.9" "distributed=2022.2")
   
   # Update protobuf on Dataproc 1.x
   if [ "$(echo "$DATAPROC_VERSION < 2.0" | bc)" -eq 1 ]; then

--- a/dask/dask.sh
+++ b/dask/dask.sh
@@ -38,8 +38,9 @@ readonly DASK_SERVICE=dask-cluster
 CONDA_PACKAGES=("dask=2022.1.1" "dask-bigquery" "dask-ml")
 
 if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
-  # Pin `distributed` pacakge version because `dask-yarn` 0.9
-  # is not compatible with `distributed` package 2022.3 and newer
+  # Pin `distributed` package version because `dask-yarn` 0.9
+  # is not compatible with `distributed` package 2022.3 and newer:
+  # https://github.com/dask/dask-yarn/issues/155
   CONDA_PACKAGES+=("dask-yarn=0.9" "distributed=2022.2")
   
   # Update protobuf on Dataproc 1.x

--- a/dask/dask.sh
+++ b/dask/dask.sh
@@ -25,8 +25,9 @@ readonly DEFAULT_CONDA_ENV=$(conda info --base)
 readonly DASK_YARN_CONFIG_DIR=/etc/dask/
 readonly DASK_YARN_CONFIG_FILE=${DASK_YARN_CONFIG_DIR}/config.yaml
 
-readonly DASK_RUNTIME="$(/usr/share/google/get_metadata_value attributes/dask-runtime || echo "yarn")"
-readonly RUN_WORKER_ON_MASTER="$(/usr/share/google/get_metadata_value attributes/dask-worker-on-master || echo "true")"
+readonly DASK_RUNTIME="$(/usr/share/google/get_metadata_value attributes/dask-runtime || echo 'yarn')"
+readonly RUN_WORKER_ON_MASTER="$(/usr/share/google/get_metadata_value attributes/dask-worker-on-master || echo 'true')"
+readonly DASK_VERSION='2022.1'
 
 readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly MASTER="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
@@ -35,18 +36,18 @@ readonly MASTER="$(/usr/share/google/get_metadata_value attributes/dataproc-mast
 readonly DASK_LAUNCHER=/usr/local/bin/dask-launcher.sh
 readonly DASK_SERVICE=dask-cluster
 
-CONDA_PACKAGES=("dask=2022.1.1" "dask-bigquery" "dask-ml")
+CONDA_PACKAGES=("dask=${DASK_VERSION}" 'dask-bigquery' 'dask-ml')
 
-if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
+if [[ "${DASK_RUNTIME}" == 'yarn' ]]; then
   # Pin `distributed` package version because `dask-yarn` 0.9
-  # is not compatible with `distributed` package 2022.3 and newer:
+  # is not compatible with `distributed` package 2022.2 and newer:
   # https://github.com/dask/dask-yarn/issues/155
-  CONDA_PACKAGES+=("dask-yarn=0.9" "distributed=2022.2")
-  
-  # Update protobuf on Dataproc 1.x
-  if [ "$(echo "$DATAPROC_VERSION < 2.0" | bc)" -eq 1 ]; then
-    CONDA_PACKAGES+=("protobuf>=3.12")
-  fi
+  CONDA_PACKAGES+=('dask-yarn=0.9' "distributed=${DASK_VERSION}")
+fi
+# Downgrade `google-cloud-bigquery` on Dataproc 2.0
+# to fix compatibility with old Arrow version
+if [[ "${DATAPROC_VERSION}" == '2.0' ]]; then
+  CONDA_PACKAGES+=('google-cloud-bigquery=2')
 fi
 readonly CONDA_PACKAGES
 
@@ -60,27 +61,6 @@ function execute_with_retries() {
   done
   echo "Cmd '${cmd}' failed."
   return 1
-}
-
-function install_conda_packages() {
-  local base
-  base=$(conda info --base)
-  local -r mamba_env_name=mamba
-  local -r mamba_env=${base}/envs/mamba
-
-  conda config --add channels conda-forge
-
-  # Create a separate environment with mamba.
-  # Mamba provides significant decreases in installation times.
-  conda create -y -n ${mamba_env_name} mamba
-
-  execute_with_retries "${mamba_env}/bin/mamba install -y ${CONDA_PACKAGES[*]} -p ${base}"
-
-  # Clean up environment
-  "${mamba_env}/bin/mamba" clean -y --all
-
-  # Remove mamba env when done
-  conda env remove -n ${mamba_env_name}
 }
 
 function configure_dask_yarn() {
@@ -147,10 +127,10 @@ EOF
 
 function main() {
   # Install conda packages
-  install_conda_packages
+  execute_with_retries "mamba install -y ${CONDA_PACKAGES[*]}"
 
   if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
-    # Create Dask Yarn config file
+    # Create Dask YARN config file
     configure_dask_yarn
   elif [[ "${DASK_RUNTIME}" == "standalone" ]]; then
     # Create Dask service

--- a/dask/test_dask.py
+++ b/dask/test_dask.py
@@ -1,4 +1,5 @@
 import os
+import pkg_resources
 from absl.testing import absltest
 from absl.testing import parameterized
 

--- a/dask/test_dask.py
+++ b/dask/test_dask.py
@@ -36,13 +36,16 @@ class DaskTestCase(DataprocTestCase):
         if self.getImageOs() == 'rocky':
             self.skipTest("Not supported in Rocky Linux-based images")
 
+        if self.getImageVersion() < pkg_resources.parse_version("2.0"):
+            self.skipTest("Not supported in pre-2.0 images")
+
         metadata = None
         if runtime:
             metadata = "dask-runtime={}".format(runtime)
 
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
-                           machine_type='n1-standard-2',
+                           machine_type='e2-standard-2',
                            metadata=metadata,
                            timeout_in_minutes=20)
         


### PR DESCRIPTION
1. Drop support for pre-2.0 images
2. Fix Dask on YARN deployment (see https://github.com/dask/dask-yarn/issues/155 for context)
3. Fix Dask BQ integration