### PR TITLE
[gpu] Avoid restarting services if not started yet

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -387,11 +387,15 @@ function main() {
   elif [[ "${ROLE}" == "Master" ]]; then
     configure_yarn_nodemanager
     configure_gpu_isolation
+  fi
+  # restart YARN services on different nodes
+  if [[ "${ROLE}" == "Master" ]]; then
     systemctl restart hadoop-yarn-resourcemanager.service
-    # Restart NodeManager on Master as well if this is a single-node-cluster.
-    if systemctl status hadoop-yarn-nodemanager; then
+  fi
+
+  # Restart NodeManager on Master as well if this is a single-node-cluster.
+  if systemctl status hadoop-yarn-nodemanager; then
       systemctl restart hadoop-yarn-nodemanager.service
-    fi
   fi
 }
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -389,11 +389,10 @@ function main() {
     configure_gpu_isolation
   fi
 
-  # restart YARN services on different nodes
+  # Restart YARN services on different nodes
   if [[ "${ROLE}" == "Master" ]]; then
     systemctl restart hadoop-yarn-resourcemanager.service
   fi
-
   # Restart NodeManager on Master as well if this is a single-node-cluster.
   if systemctl status hadoop-yarn-nodemanager; then
     systemctl restart hadoop-yarn-nodemanager.service

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -388,6 +388,7 @@ function main() {
     configure_yarn_nodemanager
     configure_gpu_isolation
   fi
+
   # restart YARN services on different nodes
   if [[ "${ROLE}" == "Master" ]]; then
     systemctl restart hadoop-yarn-resourcemanager.service
@@ -395,7 +396,7 @@ function main() {
 
   # Restart NodeManager on Master as well if this is a single-node-cluster.
   if systemctl status hadoop-yarn-nodemanager; then
-      systemctl restart hadoop-yarn-nodemanager.service
+    systemctl restart hadoop-yarn-nodemanager.service
   fi
 }
 

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -152,7 +152,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         configuration,
         self.INIT_ACTIONS,
         metadata=metadata,
-        machine_type="n1-standard-2",
+        machine_type="n1-standard-4",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         timeout_in_minutes=30)

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -152,7 +152,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         configuration,
         self.INIT_ACTIONS,
         metadata=metadata,
-        machine_type="n1-standard-4",
+        machine_type="n1-standard-8" if configuration == "SINGLE" and self.getImageOs() == "rocky" else "n1-standard-2",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         timeout_in_minutes=30)

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -139,15 +139,11 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                                 machine_suffix))
 
   @parameterized.parameters(
-      ("SINGLE", ["m"], GPU_V100, None, None),
-      ("STANDARD", ["m"], GPU_V100, GPU_V100, "NVIDIA")
+      ("SINGLE", GPU_V100, None, None),
+      ("STANDARD", GPU_V100, GPU_V100, "NVIDIA")
   )
-  def test_gpu_allocation(self, configuration, machine_suffixes,
-                          master_accelerator, worker_accelerator,
-                          driver_provider):
-    if self.getImageOs() == 'centos':
-      self.skipTest("Not supported in CentOS-based images")
-
+  def test_gpu_allocation(self, configuration, master_accelerator,
+                          worker_accelerator, driver_provider):
     metadata = None
     if driver_provider is not None:
       metadata = "gpu-driver-provider={}".format(driver_provider)


### PR DESCRIPTION
In case of 2.0+ dataproc images services are always started after the custom init actions.

So, Trying to restart services in init stage results in failure as 'ready' marker file will not be present for services to successfully start.
And exit code of init script can be non-zero due to this.

Following changes are on top of #988.