### PR TITLE
Deprecate Dataproc 1.x support for GPU agent

### DIFF
--- a/gpu/README.md
+++ b/gpu/README.md
@@ -32,7 +32,7 @@ attached GPU adapters.
 
 1.  Use the `gcloud` command to create a new cluster with NVIDIA GPU drivers
     and CUDA installed by initialization action as well as the GPU
-    monitoring service. The monitoring service is supported on Dataproc 1.4+ images.
+    monitoring service. The monitoring service is supported on Dataproc 2.0+ images. Please create a Github issue if support is needed for Dataproc 1.5.
 
     *Prerequisite:* Create GPU metrics in
     [Cloud Monitoring](https://cloud.google.com/monitoring/docs/) using Google

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -32,7 +32,7 @@ attached GPU adapters.
 
 1.  Use the `gcloud` command to create a new cluster with NVIDIA GPU drivers
     and CUDA installed by initialization action as well as the GPU
-    monitoring service. The monitoring service is supported on Dataproc 2.0+ images. Please create a Github issue if support is needed for Dataproc 1.5.
+    monitoring service. The monitoring service is supported on Dataproc 2.0+ Debian and Ubuntu images. Please create a Github issue if support is needed for Datapoc 1.5 or Dataproc 2.0+ Rocky.
 
     *Prerequisite:* Create GPU metrics in
     [Cloud Monitoring](https://cloud.google.com/monitoring/docs/) using Google

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -32,7 +32,9 @@ attached GPU adapters.
 
 1.  Use the `gcloud` command to create a new cluster with NVIDIA GPU drivers
     and CUDA installed by initialization action as well as the GPU
-    monitoring service. The monitoring service is supported on Dataproc 2.0+ Debian and Ubuntu images. Please create a Github issue if support is needed for Datapoc 1.5 or Dataproc 2.0+ Rocky.
+    monitoring service. The monitoring service is supported on Dataproc 2.0+ Debian
+    and Ubuntu images. Please create a Github issue if support is needed for other
+    Dataproc images.
 
     *Prerequisite:* Create GPU metrics in
     [Cloud Monitoring](https://cloud.google.com/monitoring/docs/) using Google

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -76,8 +76,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
                                   driver_provider):
-    if self.getImageVersion() < pkg_resources.parse_version("2.0"):
-      self.skipTest("Not supported in pre 2.0 images")
+    if self.getImageVersion() < pkg_resources.parse_version("2.0") or self.getImageOs == "rocky":
+      self.skipTest("Not supported in pre 2.0 or Rocky images")
 
     metadata = "install-gpu-agent=true"
     if driver_provider is not None:

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -75,6 +75,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
                                   driver_provider):
+    if self.getImageVersion() < pkg_resources.parse_version("2.0"):
+      self.skipTest("Not supported in pre 2.0 images")
+      
     metadata = "install-gpu-agent=true"
     if driver_provider is not None:
       metadata += ",gpu-driver-provider={}".format(driver_provider)

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -1,3 +1,4 @@
+import pkg_resources
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -77,7 +78,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                   driver_provider):
     if self.getImageVersion() < pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")
-      
+
     metadata = "install-gpu-agent=true"
     if driver_provider is not None:
       metadata += ",gpu-driver-provider={}".format(driver_provider)


### PR DESCRIPTION
The following bug is popping up in Dataproc 1.5 when configured with the GPU agent:
```
Jun 28 20:34:51 gpu-agent-1-5-m systemd[1]: gpu-utilization-agent.service: Main process exited, code=exited, st
Jun 28 20:34:51 gpu-agent-1-5-m systemd[1]: gpu-utilization-agent.service: Failed with result 'exit-code'.
Jun 28 20:34:51 gpu-agent-1-5-m systemd[1]: gpu-utilization-agent.service: Service RestartSec=100ms expired, sc
Jun 28 20:34:51 gpu-agent-1-5-m systemd[1]: gpu-utilization-agent.service: Scheduled restart job, restart count
Jun 28 20:34:51 gpu-agent-1-5-m systemd[1]: Stopped GPU Utilization Metric Agent.
Jun 28 20:34:51 gpu-agent-1-5-m systemd[1]: Started GPU Utilization Metric Agent.
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]: Traceback (most recent call last):
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:   File "/opt/gpu-utilization-agent/report_gpu_metrics.py", line 24
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:     main(args)
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:   File "/opt/gpu-utilization-agent/report_gpu_metrics.py", line 23
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:     report_metrics(resource_values, args.sleep, metrics)
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:   File "/opt/gpu-utilization-agent/report_gpu_metrics.py", line 19
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:     resource_values=resource_values)
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:   File "/opt/gpu-utilization-agent/report_gpu_metrics.py", line 11
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:     client.create_time_series(name=project_name, time_series=[seri
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:   File "/opt/conda/default/lib/python3.7/site-packages/google/clou
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:     request.time_series.extend(time_series)
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]: TypeError: Expected a message object, but got metric {
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]:   type: "custom.googleapis.com/utilization_memory"
Jun 28 20:34:52 gpu-agent-1-5-m bash[15967]: }
```

This does not appear in Dataproc 2.0. Skipping 1.5 setup and adding a note to reach out if support is still needed.
