### PR TITLE
Stream presubmit container logs until it container will be terminated

### DIFF
--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -109,6 +109,12 @@ run_tests() {
     "${TESTS_TO_RUN[@]}"
 }
 
+function delay_on_failure() {
+  local exit_code="$?"
+  sleep 10
+  exit "${exit_code}"
+}
+
 main() {
   cd /init-actions
   configure_gcloud
@@ -118,10 +124,5 @@ main() {
   run_tests
 }
 
-# Sleep for 10 seconds after presubmit failure
-# to let logs from the container to propagate
-main; EXIT_CODE="$?"
-if [[ ${EXIT_CODE} != 0 ]]; then
-  sleep 10
-  exit "${EXIT_CODE}"
-fi
+# Sleep after presubmit failure to let logs from the container to propagate
+main || delay_on_failure

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -118,5 +118,4 @@ main() {
   run_tests
 }
 
-
 main

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -118,4 +118,10 @@ main() {
   run_tests
 }
 
-main
+# Sleep for 10 seconds after presubmit failure
+# to let logs from the container to propagate
+main; EXIT_CODE="$?"
+if [[ ${EXIT_CODE} != 0 ]]; then
+  sleep 10
+  exit "${EXIT_CODE}"
+fi

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -109,12 +109,6 @@ run_tests() {
     "${TESTS_TO_RUN[@]}"
 }
 
-function delay_on_failure() {
-  local exit_code="$?"
-  sleep 10
-  exit "${exit_code}"
-}
-
 main() {
   cd /init-actions
   configure_gcloud
@@ -124,5 +118,5 @@ main() {
   run_tests
 }
 
-# Sleep after presubmit failure to let logs from the container to propagate
-main || delay_on_failure
+
+main

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -26,7 +26,7 @@ trap '[[ $? != 0 ]] && kubectl describe "pod/${POD_NAME}"; kubectl delete pods "
 kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=15m
 
 while ! kubectl describe "pod/${POD_NAME}" | grep -q Terminated; do
-  kubectl logs -f "${POD_NAME}" --since-time="${LOGS_SINCE_TIME}"
+  kubectl logs -f "${POD_NAME}" --since-time="${LOGS_SINCE_TIME}" --timestamps=true
   LOGS_SINCE_TIME=$(date --iso-8601=seconds)
 done
 

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -14,7 +14,6 @@ LOGS_START_DATE=$(date --rfc-3339=seconds)
 
 kubectl run "${POD_NAME}" \
   --image="${IMAGE}" \
-  --pod-running-timeout=15m \
   --requests='cpu=750m,memory=2Gi,ephemeral-storage=2Gi' \
   --restart=Never \
   --env="COMMIT_SHA=${COMMIT_SHA}" \
@@ -27,7 +26,7 @@ trap '[[ $? != 0 ]] && kubectl describe "pod/${POD_NAME}"; kubectl delete pods "
 kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=15m
 
 while ! kubectl describe "pod/${POD_NAME}" | grep -q Terminated; do
-  kubectl logs -f "${POD_NAME}" --pod-running-timeout --since-time=
+  kubectl logs -f "${POD_NAME}" --since-time="${LOGS_START_DATE}"
   LOGS_START_DATE=$(date --rfc-3339=seconds)
 done
 

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -10,6 +10,8 @@ readonly POD_NAME=presubmit-${DATAPROC_IMAGE_VERSION//./-}-${BUILD_ID//_/-}
 
 gcloud container clusters get-credentials "${CLOUDSDK_CONTAINER_CLUSTER}"
 
+LOGS_START_DATE=$(date --rfc-3339=seconds)
+
 kubectl run "${POD_NAME}" \
   --image="${IMAGE}" \
   --pod-running-timeout=15m \
@@ -24,16 +26,12 @@ trap '[[ $? != 0 ]] && kubectl describe "pod/${POD_NAME}"; kubectl delete pods "
 
 kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=15m
 
-kubectl logs -f "${POD_NAME}"
-
-# Wait until POD will be terminated
-wait_secs=300
-while ((wait_secs > 0)) && ! kubectl describe "pod/${POD_NAME}" | grep -q Terminated; do
-  sleep 10
-  ((wait_secs-=10))
+while ! kubectl describe "pod/${POD_NAME}" | grep -q Terminated; do
+  kubectl logs -f "${POD_NAME}" --pod-running-timeout --since-time=
+  LOGS_START_DATE=$(date --rfc-3339=seconds)
 done
 
-readonly EXIT_CODE=$(kubectl get pod "${POD_NAME}" \
+EXIT_CODE=$(kubectl get pod "${POD_NAME}" \
   -o go-template="{{range .status.containerStatuses}}{{.state.terminated.exitCode}}{{end}}")
 
 if [[ ${EXIT_CODE} != 0 ]]; then

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -10,7 +10,7 @@ readonly POD_NAME=presubmit-${DATAPROC_IMAGE_VERSION//./-}-${BUILD_ID//_/-}
 
 gcloud container clusters get-credentials "${CLOUDSDK_CONTAINER_CLUSTER}"
 
-LOGS_START_DATE=$(date --rfc-3339=seconds)
+LOGS_SINCE_TIME=$(date --rfc-3339=seconds)
 
 kubectl run "${POD_NAME}" \
   --image="${IMAGE}" \
@@ -26,8 +26,8 @@ trap '[[ $? != 0 ]] && kubectl describe "pod/${POD_NAME}"; kubectl delete pods "
 kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=15m
 
 while ! kubectl describe "pod/${POD_NAME}" | grep -q Terminated; do
-  kubectl logs -f "${POD_NAME}" --since-time="${LOGS_START_DATE}"
-  LOGS_START_DATE=$(date --rfc-3339=seconds)
+  kubectl logs -f "${POD_NAME}" --since-time="${LOGS_SINCE_TIME}"
+  LOGS_SINCE_TIME=$(date --rfc-3339=seconds)
 done
 
 EXIT_CODE=$(kubectl get pod "${POD_NAME}" \

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -10,7 +10,7 @@ readonly POD_NAME=presubmit-${DATAPROC_IMAGE_VERSION//./-}-${BUILD_ID//_/-}
 
 gcloud container clusters get-credentials "${CLOUDSDK_CONTAINER_CLUSTER}"
 
-LOGS_SINCE_TIME=$(date --rfc-3339=seconds)
+LOGS_SINCE_TIME=$(date --iso-8601=seconds)
 
 kubectl run "${POD_NAME}" \
   --image="${IMAGE}" \
@@ -27,7 +27,7 @@ kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=15m
 
 while ! kubectl describe "pod/${POD_NAME}" | grep -q Terminated; do
   kubectl logs -f "${POD_NAME}" --since-time="${LOGS_SINCE_TIME}"
-  LOGS_SINCE_TIME=$(date --rfc-3339=seconds)
+  LOGS_SINCE_TIME=$(date --iso-8601=seconds)
 done
 
 EXIT_CODE=$(kubectl get pod "${POD_NAME}" \


### PR DESCRIPTION
`kubectl logs` command sometimes exits prematurely, so we need to restart and continue logs streaming until container will be terminated.