### PR TITLE
[rapids] Adjust some Spark config defaults when using RAPIDS Accelerator

### DIFF
--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -117,6 +117,8 @@ spark.executor.resource.gpu.amount=1
 spark.plugins=com.nvidia.spark.SQLPlugin
 spark.executor.resource.gpu.discoveryScript=/usr/lib/spark/scripts/gpu/getGpusResources.sh
 spark.dynamicAllocation.enabled=false
+spark.sql.autoBroadcastJoinThreshold=10m
+spark.sql.files.maxPartitionBytes=512m
 ###### END   : RAPIDS properties for Spark ${SPARK_VERSION} ######
 EOF
   else


### PR DESCRIPTION
Adds a few more settings to the Spark defaults that are updated as part of setting up the cluster to run with the RAPIDS Accelerator.  We have found these settings to perform better that the Dataproc defaults for Spark when queries are running on the GPU.

cc: @mengdong @viadea

Signed-off-by: Jason Lowe <jlowe@nvidia.com>