### PR TITLE
Add an initialization action for installing the Toree Jupyter kernel

### DIFF
--- a/toree/BUILD
+++ b/toree/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "test_toree",
+    size = "enormous",
+    srcs = ["test_toree.py"],
+    data = ["toree.sh"],
+    local = True,
+    shard_count = 3,
+    deps = [
+        "//integration_tests:dataproc_test_case",
+        "@io_abseil_py//absl/testing:parameterized",
+    ],
+)

--- a/toree/README.md
+++ b/toree/README.md
@@ -1,0 +1,43 @@
+# Apache Toree Kernel
+
+This init action installs the [Apache Toree](https://toree.apache.org/) kernel for
+Jupyter notebooks.
+
+This init action assumes that the Jupyter optional component and the `toree` pip package
+are both installed in the cluster.
+
+## Usage
+
+**:warning: NOTICE:** See [best practices](/README.md#how-initialization-actions-are-used) of using initialization actions in production.
+
+You can create a cluster with Jupyter and the Apache Toree kernel configured using a
+command like the following:
+
+### Dataproc 2.0 (and later) images
+
+```bash
+REGION=<region>
+CLUSTER_NAME=<cluster_name>
+gcloud dataproc clusters create ${CLUSTER_NAME?} \
+  --region ${REGION?} \
+  --image-version=2.0 \
+  --enable-component-gateway \
+  --optional-components=JUPYTER \
+  --properties=dataproc:pip.packages='toree==0.5.0' \
+  --initialization-actions gs://goog-dataproc-initialization-actions-${REGION?}/toree/toree.sh
+```
+
+### Dataproc 1.5 images
+
+```bash
+REGION=<region>
+CLUSTER_NAME=<cluster_name>
+gcloud dataproc clusters create ${CLUSTER_NAME?} \
+  --region ${REGION?} \
+  --image-version=1.5 \
+  --enable-component-gateway \
+  --optional-components=ANACONDA,JUPYTER \
+  --properties=dataproc:pip.packages='toree==0.5.0' \
+  --initialization-actions gs://goog-dataproc-initialization-actions-${REGION?}/toree/toree.sh
+```
+

--- a/toree/__init__.py
+++ b/toree/__init__.py
@@ -1,0 +1,1 @@
+# This file is required for integration tests

--- a/toree/test_toree.py
+++ b/toree/test_toree.py
@@ -30,7 +30,7 @@ class ToreeTestCase(DataprocTestCase):
             properties=properties)
         instance_name = self.getClusterName() + "-" + machine_suffix
         _, stdout, _ = self.assert_instance_command(
-            instance_name, "curl http://{}:12345/api/kernelspecs".format(instance_name))
+            instance_name, "curl http://127.0.0.1:12345/api/kernelspecs")
         self.assertIn("Apache Toree", stdout)
 
 

--- a/toree/test_toree.py
+++ b/toree/test_toree.py
@@ -1,0 +1,38 @@
+import pkg_resources
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from integration_tests.dataproc_test_case import DataprocTestCase
+
+
+class ToreeTestCase(DataprocTestCase):
+    COMPONENT = 'toree'
+    INIT_ACTIONS = ['toree/toree.sh']
+
+    @parameterized.parameters(
+        ("SINGLE", "m", True),
+        ("STANDARD", "m", True),
+        ("HA", "m-0", True),
+        ("SINGLE", "m", False),
+    )
+    def test_toree(self, configuration, machine_suffix, install_explicit):
+        properties = "dataproc:jupyter.port=12345"
+        if install_explicit:
+            properties = "dataproc:pip.packages='toree==0.5.0',dataproc:jupyter.port=12345"
+        optional_components = ["JUPYTER"]
+        if self.getImageVersion() < pkg_resources.parse_version("2.0"):
+            optional_components = ["ANACONDA", "JUPYTER"]
+        self.createCluster(
+            configuration,
+            self.INIT_ACTIONS,
+            optional_components=optional_components,
+            properties=properties)
+        instance_name = self.getClusterName() + "-" + machine_suffix
+        _, stdout, _ = self.assert_instance_command(
+            instance_name, "curl http://{}:12345/api/kernelspecs".format(instance_name))
+        self.assertIn("Apache Toree", stdout)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/toree/test_toree.py
+++ b/toree/test_toree.py
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pkg_resources
 
 from absl.testing import absltest

--- a/toree/toree.sh
+++ b/toree/toree.sh
@@ -18,8 +18,21 @@
 #
 # This requires that the Jupyter optional component be enabled, and that
 # the `toree` pip package is installed.
+#
+# If the `toree` pip package is not already installed, then a pinned
+# version will be installed from PyPI. To control the specific version
+# of toree used install it ahead of time using the `dataproc:pip.packages`
+# cluster property.
 
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 if [[ "${ROLE}" == 'Master' ]]; then
+  if pip freeze | grep toree; then
+    # toree is already installed
+    true
+  else
+    # toree is not installed yet; install the latest from PyPI
+    pip install --no-deps "toree==0.5.0"
+  fi
+
   jupyter toree install --spark_home=/usr/lib/spark/
 fi

--- a/toree/toree.sh
+++ b/toree/toree.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This init script installs an Apache Toree kernel for Jupyter.
+#
+# This requires that the Jupyter optional component be enabled, and that
+# the `toree` pip package is installed.
+
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+if [[ "${ROLE}" == 'Master' ]]; then
+  jupyter toree install --spark_home=/usr/lib/spark/
+fi


### PR DESCRIPTION
Dataproc clusters currently ship with the Spylon kernel for Scala notebooks.

This new init action enables you to setup Toree as an alternative kernel for Scala