### PR TITLE
Add an initialization action to change the node manager's log directory path to local SSDs

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -23,3 +23,9 @@ gcloud dataproc clusters create ${CLUSTER_NAME?} \
 ```
 
 
+## Notes
+- Update the value of MAX_MNT_DISK_FOR_LOGS to specify the total number of local SSDs we want to use for logging. I've currently set the default to 3 but you can change according to the workload
+- Update LOGPATH to the required path under /mnt// to specify the logging directory. I've currently set it to hadoop/yarn/userlogs. So logs will go to /mnt//hadoop/yarn/userlogs
+- If there are no local SSDs, the script will not add any property to yarn-site and the default boot disk path will be used
+- If there are multiple mounts, it will create a comma separated list of paths for the property based on the MAX_MNT_DISK_FOR_LOGS setting.
+- If MAX_MNT_DISK_FOR_LOGS is greater than the actual disks, then the actual disk count will be used. If not, the configuration will be honoured.

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,0 +1,25 @@
+# Node Manager Logs
+
+This init action changes the default path of the node manager logs (/var/log/hadoop-yarn/userlogs) to the Local SSD mounts(/mnt/<mnt>/<path>). 
+The script provides a couple of configurations that can be controlled as needed.
+It also configures FluentD to look for the node manager logs in the Local SSD mounts
+
+
+## Usage
+
+**:warning: NOTICE:** See [best practices](/README.md#how-initialization-actions-are-used) of using initialization actions in production.
+
+You can create a cluster with Local SSD mounts using a command like the following. Without the initialisation script, all node manager logs would be written to the boot disk.
+
+```bash
+REGION=<region>
+CLUSTER_NAME=<cluster_name>
+gcloud dataproc clusters create ${CLUSTER_NAME?} \
+  --region ${REGION?} \
+  --image-version=2.0 \
+  --enable-component-gateway \
+  --num-worker-local-ssds 2 \
+  --initialization-actions gs://goog-dataproc-initialization-actions-${REGION?}/logging/change_to_local_ssd.sh
+```
+
+

--- a/logging/change_to_local_ssd.sh
+++ b/logging/change_to_local_ssd.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script sets the yarn.nodemanager.log-dirs value to the Local SSD mounts.
+
+# Dataproc configurations
+# MAX_MNT_DISK_FOR_LOGS is the maximum number of disks to be used for creating the logs
+# LOGPATH is the path under /mnt/<mount number> where the application logs are created
+
+readonly HADOOP_CONF_DIR='/etc/hadoop/conf'
+readonly MAX_MNT_DISK_FOR_LOGS=3
+readonly LOGPATH='hadoop/yarn/userlogs'
+
+function set_hadoop_property() {
+    local -r config_file=$1
+    local -r property=$2
+    local -r value=$3
+    bdconfig set_property \
+        --configuration_file "${HADOOP_CONF_DIR}/${config_file}" \
+        --name "${property}" --value "${value}" \
+        --clobber
+}
+
+# This function validates the MAX_MNT_DISK_FOR_LOGS variable and ensures that the value is capped at the max disks available
+function get_max_local_ssd() {
+    max_disk_no=0
+    for line in $(df -h --output=target); do
+        if [ ${line:0:4} = '/mnt' ]; then
+            disk_no=$(echo $line | cut -d "/" -f3)
+            if [ $disk_no ] >$max_disk_no; then
+                max_disk_no=${disk_no}
+            fi
+        fi
+    done
+    echo $((max_disk_no > MAX_MNT_DISK_FOR_LOGS ? MAX_MNT_DISK_FOR_LOGS : max_disk_no)) # Return the least of total disks and maximum disks to be used for logging
+}
+
+# This function constructs the log directory paths
+function construct_log_dirs() {
+    max_disk_no=$(get_max_local_ssd)
+    #echo "Max Disk = "$max_disk_no
+    disk_no=1
+    log_dirs=""
+    while [ $disk_no -le $max_disk_no ]; do
+        log_dirs+="/mnt/"$disk_no"/"$LOGPATH","
+        disk_no=$((${disk_no} + 1))
+    done
+    echo $log_dirs | sed 's/,$//g'
+}
+
+function configure_yarn() {
+    ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+    echo "Role = "$ROLE
+    logdirs=$(construct_log_dirs)
+    echo "Log dir = " $logdirs
+    if [[ "${ROLE}" != 'Master' && ! -z $logdirs ]]; then
+        # This block is entered only if the script is running on a Worker node and the logdirs variable is not empty which means
+        # that the worker has local SSDs. If not, the property is left at default
+        echo "Setting properties"
+        set_hadoop_property 'yarn-site.xml' 'yarn.nodemanager.log-dirs' $logdirs
+        echo "Complete"
+    fi
+}
+
+#Getting Container Logs of Executor from mount paths added in yarn.nodemanager.log-dirs
+function configure_fluentd() {
+  sudo sed -i 's:path:path /mnt/\*/hadoop/yarn/userlogs/*,:g' /etc/google-fluentd/config.d/dataproc-yarn-userlogs.conf
+  sudo sed -i 's:path /var/log/hadoop-yarn/:path /mnt/\*/hadoop/yarn/:g' /etc/google-fluentd/config.d/dataproc-yarn-userlogs.conf
+}
+
+
+function main() {
+    configure_yarn
+    # Adding new log paths to configure_fluentd
+    configure_fluentd
+    # Restart YARN services if they are running already
+    if [[ $(systemctl show hadoop-yarn-resourcemanager.service -p SubState --value) == 'running' ]]; then
+        systemctl restart hadoop-yarn-resourcemanager.service
+    fi
+    if [[ $(systemctl show hadoop-yarn-nodemanager.service -p SubState --value) == 'running' ]]; then
+        systemctl restart hadoop-yarn-nodemanager.service
+    fi
+    #Restart Fluentd services to reflect the new changes if they are running already
+    if [[ $(systemctl show google-fluentd.service -p SubState --value) == 'running' ]]; then
+        systemctl restart google-fluentd.service
+    fi
+}
+
+main

--- a/logging/change_to_local_ssd.sh
+++ b/logging/change_to_local_ssd.sh
@@ -15,12 +15,15 @@
 # This script sets the yarn.nodemanager.log-dirs value to the Local SSD mounts.
 
 # Dataproc configurations
+# Modify these configurations as needed
 # MAX_MNT_DISK_FOR_LOGS is the maximum number of disks to be used for creating the logs
 # LOGPATH is the path under /mnt/<mount number> where the application logs are created
-
-readonly HADOOP_CONF_DIR='/etc/hadoop/conf'
 readonly MAX_MNT_DISK_FOR_LOGS=3
 readonly LOGPATH='hadoop/yarn/userlogs'
+
+# DO NOT CHANGE THESE VARIABLES UNLESS THE SOURCE FRAMEWORKS MODIFY IT
+readonly FLUENTD_YARN_USERLOGS='/etc/google-fluentd/config.d/dataproc-yarn-userlogs.conf'
+readonly HADOOP_CONF_DIR='/etc/hadoop/conf'
 
 function set_hadoop_property() {
     local -r config_file=$1
@@ -74,9 +77,9 @@ function configure_yarn() {
 }
 
 #Getting Container Logs of Executor from mount paths added in yarn.nodemanager.log-dirs
+# This function adds the /mnt/ paths to the fluentd configuration file to the path variable
 function configure_fluentd() {
-  sudo sed -i 's:path:path /mnt/\*/hadoop/yarn/userlogs/*,:g' /etc/google-fluentd/config.d/dataproc-yarn-userlogs.conf
-  sudo sed -i 's:path /var/log/hadoop-yarn/:path /mnt/\*/hadoop/yarn/:g' /etc/google-fluentd/config.d/dataproc-yarn-userlogs.conf
+  sudo sed -i "s:path:path /mnt/\*/$LOGPATH/*,:g" $FLUENTD_YARN_USERLOGS
 }
 
 


### PR DESCRIPTION
- If there are no local SSDs, the script will not add any property to yarn-site and the default boot disk path will be used
- If there are multiple mounts, it will create a comma separated list of paths for the property based on the MAX_MNT_DISK_FOR_LOGS setting.
- If MAX_MNT_DISK_FOR_LOGS is greater than the actual disks, then the actual disk count will be used. If not, the configuration will be honoured.
- The fluentd configuration file is modified to monitor the new path for pushing to Cloud Logging