### PR TITLE
Updated timeout value

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -79,4 +79,4 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['container', 'images', 'delete', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID']
 
-timeout: 5400s
+timeout: 7200s


### PR DESCRIPTION
The gpu tests are running a series of tests and crossing the 1hour 30 mins threshold. Hence increasing the timeout value