### PR TITLE
Added an extra variable to reflect the correct node count

### DIFF
--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -175,6 +175,15 @@ function install_oozie() {
       --configuration_file "/etc/oozie/conf/oozie-site.xml" \
       --name 'oozie.zookeeper.connection.string' --value "${servers}" \
       --clobber
+
+    #Workaround to avoid classnotfound issues due to old curator jar in Oozie classpath
+    if [ -f "/usr/lib/oozie/lib/curator-framework-2.5.0.jar" ]
+    then
+	find /usr/lib/oozie/lib -name "curator-framework*.jar" -delete
+	find /usr/lib/oozie/lib -name "curator-recipes*.jar" -delete
+	find /usr/lib/oozie/lib -name "curator-client*.jar" -delete
+	cp /usr/lib/hadoop/lib/curator*-2.13.0.jar /usr/lib/oozie/lib
+    fi
   fi
 
   /usr/lib/zookeeper/bin/zkServer.sh restart

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -145,9 +145,9 @@ function install_oozie() {
   
   # Detect if current node configuration is HA and then set oozie servers
   local additional_nodes
-  additional_nodes=$(/usr/share/google/get_metadata_value attributes/dataproc-master-additional |
-    sed 's/,/\n/g' | wc -l)
-  if [[ ${additional_nodes} -ge 2 ]]; then
+  additional_nodes=$(/usr/share/google/get_metadata_value attributes/dataproc-master-additional)
+  additional_nodes_count=$(echo "$additional_nodes"| sed 's/,/\n/g' | wc -l)
+  if [[ ${additional_nodes_count} -ge 2 ]]; then
     echo 'Starting configuration for HA'
     # List of servers is used for proper zookeeper configuration.
     # It is needed to replace original ports range with specific one


### PR DESCRIPTION
With earlier logic, it was always printing node count as (actual node count  - 1 ).

Example for earlier logic:

```
kuldeepkk@cluster-oozie-init-testing-m-0:~$ /usr/share/google/get_metadata_value attributes/dataproc-master-additional|sed 's/,/\n/g'|wc -l
1
```

```
kuldeepkk@cluster-oozie-init-testing-m-0:~$ /usr/share/google/get_metadata_value attributes/dataproc-master-additional
cluster-oozie-init-testing-m-1,cluster-oozie-init-testing-m-2kuldeepkk@cluster-oozie-init-testing-m-0:~$
```
Note that there is no '\n' after the results hence line count is always (expected line count - 1)

After changing variable:

```
kuldeepkk@cluster-oozie-init-testing-m-0:~$ additional_nodes=$(/usr/share/google/get_metadata_value attributes/dataproc-master-additional)
kuldeepkk@cluster-oozie-init-testing-m-0:~$ echo $additional_nodes
cluster-oozie-init-testing-m-1,cluster-oozie-init-testing-m-2
kuldeepkk@cluster-oozie-init-testing-m-0:~$ additional_nodes_count=$(echo "$additional_nodes"| sed 's/,/\n/g' | wc -l)
kuldeepkk@cluster-oozie-init-testing-m-0:~$ echo $additional_nodes_count
2
```