### PR TITLE
[rapids]add a cleaner error message for supported cuda versions

### DIFF
--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -56,6 +56,14 @@ readonly -A DEFAULT_NVIDIA_DEBIAN_CUDA_URLS=(
   [11.6]="${NVIDIA_BASE_DL_URL}/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run"
   [11.7]="${NVIDIA_BASE_DL_URL}/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run"
   [11.8]="${NVIDIA_BASE_DL_URL}/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run")
+
+if [[ ${!DEFAULT_NVIDIA_DEBIAN_CUDA_URLS[@]} =~ ${CUDA_VERSION} ]]; then
+  echo "CUDA version ${CUDA_VERSION} is supported."
+else
+  echo "Error: CUDA version ${CUDA_VERSION} is not supported. Supported version : ${!DEFAULT_NVIDIA_DEBIAN_CUDA_URLS[@]}"
+  exit 1
+fi
+
 readonly DEFAULT_NVIDIA_DEBIAN_CUDA_URL=${DEFAULT_NVIDIA_DEBIAN_CUDA_URLS["${CUDA_VERSION}"]}
 NVIDIA_DEBIAN_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_DEBIAN_CUDA_URL}")
 readonly NVIDIA_DEBIAN_CUDA_URL

--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -250,6 +250,7 @@ function install_nvidia_gpu_driver() {
       curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
         "${NVIDIA_UBUNTU_REPO_CUDA_PIN}" -o /etc/apt/preferences.d/cuda-repository-pin-600
 
+      apt-key adv --fetch-keys ${NVIDIA_UBUNTU_REPO_URL}/3bf863cc.pub
       add-apt-repository "deb ${NVIDIA_UBUNTU_REPO_URL} /"
       execute_with_retries "apt-get update"
 


### PR DESCRIPTION
This pr is to fix this [issue](https://github.com/NVIDIA/spark-rapids/issues/8149).
Add a cleaner error message for supported cuda versions.
And fix a error for ubuntu20-img2.1 version.