### PR TITLE
Fixes to enable connectors on 2.1 images

### DIFF
--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -27,15 +27,6 @@ readonly BIGQUERY_CONNECTOR_URL=$(/usr/share/google/get_metadata_value attribute
 readonly SPARK_BIGQUERY_CONNECTOR_URL=$(/usr/share/google/get_metadata_value attributes/spark-bigquery-connector-url || true)
 readonly HIVE_BIGQUERY_CONNECTOR_URL=$(/usr/share/google/get_metadata_value attributes/hive-bigquery-connector-url || true)
 
-is_worker() {
-  local role
-  role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
-  if [[ $role != Master ]]; then
-    return 0
-  fi
-  return 1
-}
-
 min_version() {
   echo -e "$1\n$2" | sort -r -t'.' -n -k1,1 -k2,2 -k3,3 | tail -n1
 }
@@ -63,7 +54,8 @@ function get_connector_url() {
 
   # spark-bigquery
   if [[ $name == spark-bigquery ]]; then
-    readonly -A LT_DP_VERSION_SCALA=([2.0]="2.11" # On Dataproc images < 2.0, use Scala 2.11
+    readonly -A LT_DP_VERSION_SCALA=([1.5]="2.11" # On Dataproc images < 1.5, use Scala 2.11
+                                     [2.0]="2.12" # On Dataproc images < 2.0, use Scala 2.12
                                      [2.1]="2.12" # On Dataproc images < 2.1, use Scala 2.12
                                      [2.2]="2.13" # On Dataproc images < 2.2, use Scala 2.13
                                     )
@@ -71,7 +63,7 @@ function get_connector_url() {
     # cluster.  We will use this to determine the appropriate connector to use
     # based on the scala version.
 
-    for LT_DP_VER in 2.0 2.1 2.2 ; do
+    for LT_DP_VER in 1.5 2.0 2.1 2.2 ; do
       if ! test -v scala_version && compare_versions_lt $DATAPROC_IMAGE_VERSION ${LT_DP_VER} ; then
         local -r scala_version=${LT_DP_VERSION_SCALA[${LT_DP_VER}]}
         continue

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -79,8 +79,8 @@ function get_connector_url() {
     done
 
     if compare_versions_lt $DATAPROC_IMAGE_VERSION 2.0 ; then
-      if ! compare_version_lte ${version} 0.30.0 ; then
-        echo "spark-bigquery-with-dependencies version ${version} does not target scala versions above 0.29.* (${scala_version})" >&2
+      if ! compare_versions_lt ${version} 0.30.0 ; then
+        echo "spark-bigquery-with-dependencies version ${version} does not target scala versions below 2.12 (${scala_version})" >&2
         exit -1
       fi
     fi

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -53,7 +53,7 @@ function get_connector_url() {
   local -r version=$2
 
   # spark-bigquery
-  if [[ $name == spark-bigquery ]]; then
+  if [[ "${name}" == spark-bigquery ]]; then
     # DATAPROC_IMAGE_VERSION is built from an environment variable set on the
     # cluster.  We will use this to determine the appropriate connector to use
     # based on the scala version.
@@ -102,9 +102,9 @@ function get_connector_url() {
 validate_version() {
   local name=$1    # connector name: "bigquery" or "spark-bigquery"
   local version=$2 # connector version
-  local min_valid_version=${MIN_CONNECTOR_VERSIONS[$name]}
-  if [[ "$(min_version "$min_valid_version" "$version")" != "$min_valid_version" ]]; then
-    echo "ERROR: ${name}-connector version should be greater than or equal to $min_valid_version, but was $version"
+  local min_valid_version="${MIN_CONNECTOR_VERSIONS[${name}]}"
+  if [[ "$(min_version "${min_valid_version}" "${version}")" != "${min_valid_version}" ]]; then
+    echo "ERROR: ${name}-connector version should be greater than or equal to ${min_valid_version}, but was ${version}"
     return 1
   fi
 }
@@ -126,7 +126,7 @@ update_connector_url() {
     local pattern="${name}-connector-*.jar"
   fi
 
-  find "${vm_connectors_dir}/" -name "$pattern" -delete
+  find "${vm_connectors_dir}/" -name "${pattern}" -delete
 
   gsutil cp -P "${url}" "${vm_connectors_dir}/"
 
@@ -141,11 +141,11 @@ update_connector_version() {
   local -r version=$2 # connector version
 
   # validate new connector version
-  validate_version "$name" "$version"
+  validate_version "${name}" "${version}"
 
-  local -r connector_url=$(get_connector_url "$name" "$version")
+  local -r connector_url=$(get_connector_url "${name}" "${version}")
 
-  update_connector_url "$name" "$connector_url"
+  update_connector_url "${name}" "${connector_url}"
 }
 
 update_connector() {
@@ -153,27 +153,27 @@ update_connector() {
   local -r version=$2
   local -r url=$3
 
-  if [[ -n $version && -n $url ]]; then
+  if [[ -n "${version}" && -n "${url}" ]]; then
     echo "ERROR: Both, connector version and URL are specified for the same connector"
     exit 1
   fi
 
-  if [[ -n $version ]]; then
-    update_connector_version "$name" "$version"
+  if [[ -n "${version}" ]]; then
+    update_connector_version "${name}" "${version}"
   fi
 
-  if [[ -n $url ]]; then
-    update_connector_url "$name" "$url"
+  if [[ -n "${url}" ]]; then
+    update_connector_url "${name}" "${url}"
   fi
 }
 
-if [[ -z $BIGQUERY_CONNECTOR_VERSION && -z $BIGQUERY_CONNECTOR_URL ]] &&
-  [[ -z $HIVE_BIGQUERY_CONNECTOR_VERSION && -z $HIVE_BIGQUERY_CONNECTOR_URL ]] &&
-  [[ -z $SPARK_BIGQUERY_CONNECTOR_VERSION && -z $SPARK_BIGQUERY_CONNECTOR_URL ]]; then
+if [[ -z "${BIGQUERY_CONNECTOR_VERSION}" && -z "${BIGQUERY_CONNECTOR_URL}" ]] &&
+  [[ -z "${HIVE_BIGQUERY_CONNECTOR_VERSION}" && -z "${HIVE_BIGQUERY_CONNECTOR_URL}" ]] &&
+  [[ -z "${SPARK_BIGQUERY_CONNECTOR_VERSION}" && -z "${SPARK_BIGQUERY_CONNECTOR_URL}" ]]; then
   echo "ERROR: None of connector versions or URLs are specified"
   exit 1
 fi
 
-update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION" "$BIGQUERY_CONNECTOR_URL"
-update_connector "spark-bigquery" "$SPARK_BIGQUERY_CONNECTOR_VERSION" "$SPARK_BIGQUERY_CONNECTOR_URL"
-update_connector "hive-bigquery" "$HIVE_BIGQUERY_CONNECTOR_VERSION" "$HIVE_BIGQUERY_CONNECTOR_URL"
+update_connector "bigquery" "${BIGQUERY_CONNECTOR_VERSION}" "${BIGQUERY_CONNECTOR_URL}"
+update_connector "spark-bigquery" "${SPARK_BIGQUERY_CONNECTOR_VERSION}" "${SPARK_BIGQUERY_CONNECTOR_URL}"
+update_connector "hive-bigquery" "${HIVE_BIGQUERY_CONNECTOR_VERSION}" "${HIVE_BIGQUERY_CONNECTOR_URL}"

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -78,6 +78,13 @@ function get_connector_url() {
       fi
     done
 
+    if compare_versions_lt $DATAPROC_IMAGE_VERSION 2.0 ; then
+      if ! compare_version_lte ${version} 0.30.0 ; then
+        echo "spark-bigquery-with-dependencies version ${version} does not target scala versions above 0.29.* (${scala_version})" >&2
+        exit -1
+      fi
+    fi
+
     if ! test -v scala_version ; then
       echo "unsupported DATAPROC_IMAGE_VERSION" >&2
       exit -1

--- a/connectors/test_connectors.py
+++ b/connectors/test_connectors.py
@@ -12,8 +12,8 @@ class ConnectorsTestCase(DataprocTestCase):
     BQ_CONNECTOR_VERSION = "1.2.0"
     BQ_CONNECTOR_URL = "gs://hadoop-lib/bigquery/bigquery-connector-{}-1.2.0.jar"
 
-    SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
-    SPARK_BQ_CONNECTOR_URL = "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_{}-0.31.1.jar"
+    SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
+    SPARK_BQ_CONNECTOR_URL = "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_{}-0.29.0.jar"
 
     def verify_instances(self, cluster, instances, connector,
                          connector_version):

--- a/connectors/test_connectors.py
+++ b/connectors/test_connectors.py
@@ -12,8 +12,8 @@ class ConnectorsTestCase(DataprocTestCase):
     BQ_CONNECTOR_VERSION = "1.2.0"
     BQ_CONNECTOR_URL = "gs://hadoop-lib/bigquery/bigquery-connector-{}-1.2.0.jar"
 
-    SPARK_BQ_CONNECTOR_VERSION = "0.19.1"
-    SPARK_BQ_CONNECTOR_URL = "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_{}-0.19.1.jar"
+    SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
+    SPARK_BQ_CONNECTOR_URL = "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_{}-0.31.1.jar"
 
     def verify_instances(self, cluster, instances, connector,
                          connector_version):

--- a/connectors/test_connectors.py
+++ b/connectors/test_connectors.py
@@ -15,11 +15,11 @@ class ConnectorsTestCase(DataprocTestCase):
     BQ_CONNECTOR_VERSION = "1.2.0"
     BQ_CONNECTOR_URL = "gs://hadoop-lib/bigquery/bigquery-connector-{}-1.2.0.jar"
 
-    # if image version is less than 2.0:
-    SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
-    # else
-    #   SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
-    # fi
+    if self.getImageVersion() < pkg_resources.parse_version("1.5"):
+        SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
+    else:
+        SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
+
     SPARK_BQ_CONNECTOR_URL = "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_{}-{}.jar"
 
     def verify_instances(self, cluster, instances, connector,
@@ -100,13 +100,8 @@ class ConnectorsTestCase(DataprocTestCase):
           self.skipTest("Not supported in Rocky Linux-based images")
 
         logging.warning("image version: " + str( self.getImageVersion() ) )
-
-        if self.getImageVersion() == "1.5":
-            self.SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
-        else:
-            self.SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
-
         logging.warning("SPARK_BQ_CONNECTOR_VERSION=" + self.SPARK_BQ_CONNECTOR_VERSION )
+        logging.warning("scala_version=" + self._scala_version())
 
         self.createCluster(configuration,
                            self.INIT_ACTIONS,

--- a/connectors/test_connectors.py
+++ b/connectors/test_connectors.py
@@ -9,16 +9,15 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 logging.basicConfig(level=os.getenv("LOG_LEVEL", logging.INFO))
 
 class ConnectorsTestCase(DataprocTestCase):
+
+
+    SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
     COMPONENT = "connectors"
     INIT_ACTIONS = ['connectors/connectors.sh']
 
     BQ_CONNECTOR_VERSION = "1.2.0"
     BQ_CONNECTOR_URL = "gs://hadoop-lib/bigquery/bigquery-connector-{}-1.2.0.jar"
 
-    if self.getImageVersion() < pkg_resources.parse_version("1.5"):
-        SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
-    else:
-        SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
 
     SPARK_BQ_CONNECTOR_URL = "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_{}-{}.jar"
 
@@ -67,6 +66,11 @@ class ConnectorsTestCase(DataprocTestCase):
     @parameterized.parameters(("SINGLE", ["m"]),
                               ("HA", ["m-0", "m-1", "m-2", "w-0", "w-1"]))
     def test_spark_bq_connector_version(self, configuration, instances):
+        if self.getImageVersion() < pkg_resources.parse_version("1.5"):
+            self.SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
+        else:
+            self.SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
+
         if self.getImageOs() == 'rocky':
           self.skipTest("Not supported in Rocky Linux-based images")
 
@@ -82,6 +86,11 @@ class ConnectorsTestCase(DataprocTestCase):
     @parameterized.parameters(("SINGLE", ["m"]),
                               ("HA", ["m-0", "m-1", "m-2", "w-0", "w-1"]))
     def test_bq_connector_url(self, configuration, instances):
+        if self.getImageVersion() < pkg_resources.parse_version("1.5"):
+            self.SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
+        else:
+            self.SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
+
         if self.getImageOs() == 'rocky':
           self.skipTest("Not supported in Rocky Linux-based images")
 
@@ -96,6 +105,11 @@ class ConnectorsTestCase(DataprocTestCase):
     @parameterized.parameters(("SINGLE", ["m"]),
                               ("HA", ["m-0", "m-1", "m-2", "w-0", "w-1"]))
     def test_spark_bq_connector_url(self, configuration, instances):
+        if self.getImageVersion() < pkg_resources.parse_version("1.5"):
+            self.SPARK_BQ_CONNECTOR_VERSION = "0.29.0"
+        else:
+            self.SPARK_BQ_CONNECTOR_VERSION = "0.31.1"
+
         if self.getImageOs() == 'rocky':
           self.skipTest("Not supported in Rocky Linux-based images")
 


### PR DESCRIPTION
* In 2.1 images, environment variable is DATAPROC_IMAGE_VERSION
* added functions to compare versions
* When image version is >= 2.1, use scala v2.13