### PR TITLE
Added OpenTelemetry Initialization action for Dataproc clusters (along with integration tests)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -72,19 +72,6 @@ py_test(
 )
 
 py_test(
-    name = "test_open_telemetry_agent",
-    size = "enormous",
-    srcs = ["otel/test_otel.py"],
-    data = ["otel/otel.sh"],
-    local = True,
-    shard_count = 3,
-    deps = [
-        "//integration_tests:dataproc_test_case",
-        "@io_abseil_py//absl/testing:parameterized",
-    ],
-)
-
-py_test(
     name = "test_dr_elephant",
     size = "enormous",
     srcs = ["dr-elephant/test_dr_elephant.py"],

--- a/otel/BUILD
+++ b/otel/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["otel.sh"])
+
+py_test(
+    name = "test_open_telemetry_agent",
+    size = "enormous",
+    srcs = ["otel/test_otel.py"],
+    data = ["otel/otel.sh"],
+    local = True,
+    shard_count = 3,
+    deps = [
+        "//integration_tests:dataproc_test_case",
+        "@io_abseil_py//absl/testing:parameterized",
+    ],
+)

--- a/otel/BUILD
+++ b/otel/BUILD
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["otel.sh"])
-
 py_test(
     name = "test_open_telemetry_agent",
     size = "enormous",

--- a/otel/BUILD
+++ b/otel/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 py_test(
-    name = "test_open_telemetry_agent",
+    name = "test_otel",
     size = "enormous",
     srcs = ["otel/test_otel.py"],
     data = ["otel/otel.sh"],

--- a/otel/BUILD
+++ b/otel/BUILD
@@ -3,8 +3,8 @@ package(default_visibility = ["//visibility:public"])
 py_test(
     name = "test_otel",
     size = "enormous",
-    srcs = ["otel/test_otel.py"],
-    data = ["otel/otel.sh"],
+    srcs = ["test_otel.py"],
+    data = ["otel.sh"],
     local = True,
     shard_count = 3,
     deps = [

--- a/otel/otel.sh
+++ b/otel/otel.sh
@@ -76,7 +76,7 @@ function main(){
   if [ "${ROLE}" != 'Master' ] && [ $MASTER_ONLY == true ]; then
     return
   fi
-  
+
   install_otel
   configure_endpoints
   configure_otel

--- a/otel/otel.sh
+++ b/otel/otel.sh
@@ -14,11 +14,11 @@ function install_otel() {
   # Install otelcol-contrib as package (https://github.com/open-telemetry/opentelemetry-collector-contrib)
   local -r download_url="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${version}/otelcol-contrib_${version}_linux_amd64"
   if [[ "${OS_NAME}" == "rocky" ]]; then
-    wget ${download_url}.deb
-    dpkg -i "otelcol-contrib_${version}_linux_amd64.deb"
-  else
     wget ${download_url}.rpm
     yum install -y "otelcol-contrib_${version}_linux_amd64.rpm"
+  else
+    wget ${download_url}.deb
+    dpkg -i "otelcol-contrib_${version}_linux_amd64.deb"
   fi
 }
 

--- a/otel/otel.sh
+++ b/otel/otel.sh
@@ -34,7 +34,7 @@ function configure_endpoints() {
 
   # Remove the extra comma if endpoints passed
   length=${#prometheus_scrape_endpoints}
-  if [ $length -gt 0 ]; then
+  if [ ${length} -gt 0 ]; then
       prometheus_scrape_endpoints="${prometheus_scrape_endpoints: : -1}"
   fi
 }

--- a/otel/otel.sh
+++ b/otel/otel.sh
@@ -4,15 +4,22 @@
 # configures OTel and pulls metrics from Prometheus endpoints provided by the customer. 
 # The metrics are then exported to Google Cloud Monitoring (GCM).
 
+readonly version="0.81.0"
+readonly OS_NAME=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
 readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly PROMETHEUS_ENDPOINTS="$(/usr/share/google/get_metadata_value attributes/prometheus-scrape-endpoints || '')"
 readonly MASTER_ONLY="$(/usr/share/google/get_metadata_value attributes/master-only || false)"
-readonly version="0.81.0"
 
 function install_otel() {
   # Install otelcol-contrib as package (https://github.com/open-telemetry/opentelemetry-collector-contrib)
-  wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.81.0/otelcol-contrib_0.81.0_linux_amd64.deb
-  dpkg -i "otelcol-contrib_${version}_linux_amd64.deb"
+  local -r download_url="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${version}/otelcol-contrib_${version}_linux_amd64"
+  if [[ "${OS_NAME}" == "rocky" ]]; then
+    wget ${download_url}.deb
+    dpkg -i "otelcol-contrib_${version}_linux_amd64.deb"
+  else
+    wget ${download_url}.rpm
+    yum install -y "otelcol-contrib_${version}_linux_amd64.rpm"
+  fi
 }
 
 function configure_endpoints() {

--- a/otel/test_otel.py
+++ b/otel/test_otel.py
@@ -5,31 +5,17 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 
 
 class OpenTelemetryTestCase(DataprocTestCase):
-  COMPONENT = 'open-telemetry-agent'
+  COMPONENT = 'otel'
   INIT_ACTIONS = ['otel/otel.sh']
-  TEST_SCRIPT_FILE_NAME = 'otel/test_otel.py'
-
-  @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-
-    cls.PROJECT_METADATA = '{}:{}'.format(cls.PROJECT, cls.REGION)
-
-  def setUp(self):
-    super().setUp()
-
-  def tearDown(self):
-    super().tearDown()
 
   def verify_service_status(self):
     self.assert_command(cmd="systemctl status otelcol-contrib")
 
   @parameterized.parameters(
-      'SINGLE',
-      'STANDARD',
-      'HA',
+    'SINGLE',
+    'STANDARD',
   )
-  def test_cloud_sql_proxy(self, configuration):
+  def test_otel(self, configuration):
     self.createCluster(configuration, self.INIT_ACTIONS)
     self.verify_service_status()
 

--- a/otel/test_otel.py
+++ b/otel/test_otel.py
@@ -9,7 +9,8 @@ class OpenTelemetryTestCase(DataprocTestCase):
   INIT_ACTIONS = ['otel/otel.sh']
 
   def verify_service_status(self):
-    self.assert_command(cmd="systemctl status otelcol-contrib")
+    instance_name = self.getClusterName() + 'm'
+    self.assert_instance_command(instance=instance_name, cmd="systemctl status otelcol-contrib")
 
   @parameterized.parameters(
     'SINGLE',

--- a/otel/test_otel.py
+++ b/otel/test_otel.py
@@ -9,7 +9,7 @@ class OpenTelemetryTestCase(DataprocTestCase):
   INIT_ACTIONS = ['otel/otel.sh']
 
   def verify_service_status(self):
-    instance_name = self.getClusterName() + 'm'
+    instance_name = self.getClusterName() + '-m'
     self.assert_instance_command(instance=instance_name, cmd="systemctl status otelcol-contrib")
 
   @parameterized.parameters(

--- a/otel/test_otel.py
+++ b/otel/test_otel.py
@@ -7,7 +7,7 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 class OpenTelemetryTestCase(DataprocTestCase):
   COMPONENT = 'open-telemetry-agent'
   INIT_ACTIONS = ['otel/otel.sh']
-  TEST_SCRIPT_FILE_NAME = 'otel/test-otel.py'
+  TEST_SCRIPT_FILE_NAME = 'otel/test_otel.py'
 
   @classmethod
   def setUpClass(cls):


### PR DESCRIPTION
- Original PR: #1072 
- Added integration test against OpenTelemetry init action
- Added support for rocky-8

PR credits: @shambhavirai16
Original author could not continue contribution.