### PR TITLE
update spark rapids version to 23.08.1

### DIFF
--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -15,7 +15,7 @@ readonly DATAPROC_IMAGE_VERSION
 readonly OS_NAME
 
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
-readonly DEFAULT_SPARK_RAPIDS_VERSION="23.06.0"
+readonly DEFAULT_SPARK_RAPIDS_VERSION="23.08.1"
 
 if [[ "${SPARK_VERSION_ENV}" == "3"* ]]; then
   readonly DEFAULT_CUDA_VERSION="11.5"


### PR DESCRIPTION
This PR updates spark-rapids.sh init script with the latest 23.08.1 (to-date) rapids-4-spark version.

signed-off-by: Suraj Aralihalli <suraj.ara16@gmail.com>