### PR TITLE
[bigtable] Update bigtable for 2.1 images

### DIFF
--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -29,7 +29,7 @@ if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
 fi
 
 readonly HBASE_HOME='/usr/lib/hbase'
-mkdir -p "${HBASE_HOME}/lib"
+mkdir -p "${HBASE_HOME}/{lib,conf,logs}"
 
 readonly BIGTABLE_HBASE_CLIENT_1X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-1.x-hadoop"
 readonly BIGTABLE_HBASE_CLIENT_1X_VERSION='1.29.2'
@@ -137,7 +137,6 @@ EOF
       --source_configuration_file "$hbase_config" \
       --clobber
   else
-    mkdir -p "${HBASE_HOME}/conf"
     cp "$hbase_config" "${HBASE_HOME}/conf/hbase-site.xml"
   fi
 }
@@ -174,7 +173,6 @@ EOF
       --source_configuration_file "$hbase_config" \
       --clobber
   else
-    mkdir -p "${HBASE_HOME}/conf"
     cp "$hbase_config" "${HBASE_HOME}/conf/hbase-site.xml"
   fi
 

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -38,16 +38,20 @@ readonly BIGTABLE_HBASE_CLIENT_1X_URL="${BIGTABLE_HBASE_CLIENT_1X_REPO}/${BIGTAB
 
 readonly BIGTABLE_HBASE_CLIENT_2X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x"
 readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.7.4'
+#readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.3.6'
 readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_2X_URL="${BIGTABLE_HBASE_CLIENT_2X_REPO}/${BIGTABLE_HBASE_CLIENT_2X_VERSION}/${BIGTABLE_HBASE_CLIENT_2X_JAR}"
 
 case "${DATAPROC_IMAGE_VERSION}" in
   "1.3" | "1.4" | "1.5" | "2.0" )
-    readonly HBASE_VERSION="2.4.17"
+    readonly HBASE_VERSION="2.3.6"
     ;;
 
   "2.1")
-    readonly HBASE_VERSION="3.0.0-alpha-4"
+    #    readonly HBASE_VERSION="3.0.0-alpha-4"
+    # customer in CASE_NUMBER=47245247 uses 2.9.0
+    readonly HBASE_VERSION="2.3.6"
+    #readonly HBASE_VERSION="2.9.0"
     ;;
 esac
 
@@ -281,7 +285,7 @@ function install_hbase() {
         local VARIANT="bin"
         local BASENAME="hbase-${HBASE_VERSION}-${VARIANT}.tar.gz"
         echo "hbase dist basename: ${BASENAME}"
-        wget "https://dlcdn.apache.org/hbase/${HBASE_VERSION}/${BASENAME}" -P /tmp || err 'Unable to download tar'
+        wget "https://archive.apache.org/dist/hbase/${HBASE_VERSION}/${BASENAME}" -P /tmp || err 'Unable to download tar'
 
         # extract binaries from bundle
         mkdir -p "/tmp/hbase-${HBASE_VERSION}/" "${HBASE_HOME}" 

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -59,6 +59,10 @@ readonly SHC_URL="${SCH_REPO}/shc-core/${SHC_VERSION}/${SHC_JAR}"
 readonly SHC_EXAMPLES_URL="${SCH_REPO}/shc-examples/${SHC_VERSION}/${SHC_EXAMPLES_JAR}"
 
 readonly BIGTABLE_INSTANCE="$(/usr/share/google/get_metadata_value attributes/bigtable-instance)"
+if [[ -z "${BIGTABLE_INSTANCE}" ]]; then
+  echo "failed to determine bigtable-instance attribute ; https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/bigtable#using-this-initialization-action"
+  exit 1
+fi
 readonly BIGTABLE_PROJECT="$(/usr/share/google/get_metadata_value attributes/bigtable-project ||
     /usr/share/google/get_metadata_value ../project/project-id)"
 
@@ -236,7 +240,7 @@ function install_hbase() {
         #   exit 1
         # fi
 
-        # To build the hbase-connectors jar 
+        # To build the hbase-connectors jar
         # DEPENDENCIES="maven"
         # local tmp_dir=$(mktemp -d -t bigtable-init-action-hbase-XXXX)
         # HBASE_SPARK_JAR="${tmp_dir}/hbase-connectors/spark/hbase-spark/target/hbase-spark-1.0.1-SNAPSHOT.jar"
@@ -289,6 +293,7 @@ function install_hbase() {
         # install hbase and hbase-config.sh into normal user $PATH
         ln -sf ${HBASE_HOME}/bin/hbase /usr/bin/
         ln -sf ${HBASE_HOME}/bin/hbase-config.sh /usr/bin/
+
         ;;
       "*")
         echo "unsupported DATAPROC_IMAGE_VERSION: ${DATAPROC_IMAGE_VERSION}" >&2

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -194,35 +194,6 @@ function install_hbase() {
         tar xzf "/tmp/hbase-${HBASE_VERSION}-bin.tar.gz" -C /tmp/
         mkdir -p "${HBASE_HOME}"
         cp -a "/tmp/hbase-${HBASE_VERSION}/." "${HBASE_HOME}/"
-
-      #   DEPENDENCIES="maven"
-      #   local tmp_dir=$(mktemp -d -t bigtable-init-action-hbase-XXXX)
-      #   HBASE_SPARK_JAR="${tmp_dir}/hbase-connectors/spark/hbase-spark/target/hbase-spark-1.0.1-SNAPSHOT.jar"
-
-      #   # This repository only works for cloudera clusters
-      #   # wget https://archive.cloudera.com/p/HDP/2.x/2.6.3.0/${distribution}/hdp.list -O /etc/apt/sources.list.d/hdp.list
-
-      #   retry_command "apt-get update" || err 'Unable to update packages lists.'
-      #   retry_command "apt-get install -y ${DEPENDENCIES}" || err 'Unable to install dependencies.'
-
-      #   cd $tmp_dir
-      #   git clone https://github.com/apache/hbase-connectors.git
-      #   cd hbase-connectors
-      #   # These versions are from https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.1
-      #   # except hbase, which is the maximal stable version from https://hbase.apache.org/downloads.html
-      #   mvn -Dspark.version=3.3.2 \
-      #     -Dscala.version=2.12.14 \
-      #     -Dhadoop-three.version=3.3.3 \
-      #     -Dscala.binary.version=2.12 \
-      #     -Dhbase.version=2.5.5-hadoop3 \
-      #     clean install \
-      #     -DskipTests
-      #   cp "${HBASE_SPARK_JAR}" /usr/lib/spark/
-
-      #   # clean up a bit
-      #   mvn dependency:purge-local-repository
-      #   apt-get remove -y maven
-      #   apt-get clean
         ;;
       "*")
         echo "unsupported DATAPROC_IMAGE_VERSION: ${DATAPROC_IMAGE_VERSION}" >&2

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#    Copyright 2018 Google, Inc.
+#    Copyright 2018,2023 Google LLC
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,17 +21,26 @@ set -euxo pipefail
 # Use Python from /usr/bin instead of /opt/conda.
 export PATH=/usr/bin:$PATH
 
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+
+# Detect dataproc image version from its various names
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
+  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
+fi
+
 readonly HBASE_HOME='/usr/lib/hbase'
 
 readonly BIGTABLE_HBASE_CLIENT_1X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-1.x-hadoop"
-readonly BIGTABLE_HBASE_CLIENT_1X_VERSION='1.26.1'
+readonly BIGTABLE_HBASE_CLIENT_1X_VERSION='1.29.2'
 readonly BIGTABLE_HBASE_CLIENT_1X_JAR="bigtable-hbase-1.x-hadoop-${BIGTABLE_HBASE_CLIENT_1X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_1X_URL="${BIGTABLE_HBASE_CLIENT_1X_REPO}/${BIGTABLE_HBASE_CLIENT_1X_VERSION}/${BIGTABLE_HBASE_CLIENT_1X_JAR}"
 
-readonly BIGTABLE_HBASE_CLIENT_2X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x-hadoop"
-readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='1.26.1'
-readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-hadoop-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
+readonly BIGTABLE_HBASE_CLIENT_2X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x"
+readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.7.4'
+readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_2X_URL="${BIGTABLE_HBASE_CLIENT_2X_REPO}/${BIGTABLE_HBASE_CLIENT_2X_VERSION}/${BIGTABLE_HBASE_CLIENT_2X_JAR}"
+
+readonly HBASE_VERSION="2.4.17"
 
 readonly SCH_REPO="https://repo.hortonworks.com/content/groups/public/com/hortonworks"
 readonly SHC_VERSION='1.1.1-2.1-s_2.11'
@@ -61,8 +70,14 @@ function err() {
 }
 
 function install_bigtable_client() {
-  local -r bigtable_hbase_client_jar="$1"
-  local -r bigtable_hbase_client_url="$2"
+  if [[ ${DATAPROC_IMAGE_VERSION%%.*} -ge 2 ]]; then
+    local -r bigtable_hbase_client_jar="$BIGTABLE_HBASE_CLIENT_2X_JAR"
+    local -r bigtable_hbase_client_url="$BIGTABLE_HBASE_CLIENT_2X_URL"
+  else
+    local -r bigtable_hbase_client_jar="$BIGTABLE_HBASE_CLIENT_1X_JAR"
+    local -r bigtable_hbase_client_url="$BIGTABLE_HBASE_CLIENT_1X_URL"
+  fi
+
   local out="${HBASE_HOME}/lib/${bigtable_hbase_client_jar}"
   wget -nv --timeout=30 --tries=5 --retry-connrefused \
     "${bigtable_hbase_client_url}" -O "${out}"
@@ -155,27 +170,78 @@ SPARK_DIST_CLASSPATH="${SPARK_DIST_CLASSPATH}:/usr/lib/hbase/lib/*"
 SPARK_DIST_CLASSPATH="${SPARK_DIST_CLASSPATH}:/etc/hbase/conf"
 EOF
 
-  if [[ ${DATAPROC_VERSION%%.*} -ge 2 ]]; then
+  if [[ ${DATAPROC_IMAGE_VERSION%%.*} -ge 2 ]]; then
     configure_bigtable_client_2x || err 'Failed to configure big table 2.x client.'
   else
     configure_bigtable_client_1x || err 'Failed to configure big table 1.x client.'
   fi
 }
 
-function main() {
+function install_hbase() {
   if command -v apt-get >/dev/null; then
-    retry_command "apt-get update" || err 'Unable to update packages lists.'
-    retry_command "apt-get install -y hbase" || err 'Unable to install HBase.'
+    case "${DATAPROC_IMAGE_VERSION}" in
+      "1.3" | "1.4" | "1.5" | "2.0" )
+
+        # Prior to Dataproc 2.1, hbase could be installed from dpkg repositories
+        retry_command "apt-get update" || err 'Unable to update packages lists.'
+        retry_command "apt-get install -y hbase" || err 'Unable to install HBase.'
+        ;;
+
+      "2.1")
+        # get hbase tar from official site
+        wget "https://dlcdn.apache.org/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz" -P /tmp || err 'Unable to download tar'
+        # extract binaries from bundle
+        tar xzf "/tmp/hbase-${HBASE_VERSION}-bin.tar.gz" -C /tmp/
+        mkdir -p "${HBASE_HOME}"
+        cp -a "/tmp/hbase-${HBASE_VERSION}/." "${HBASE_HOME}/"
+
+      #   DEPENDENCIES="maven"
+      #   local tmp_dir=$(mktemp -d -t bigtable-init-action-hbase-XXXX)
+      #   HBASE_SPARK_JAR="${tmp_dir}/hbase-connectors/spark/hbase-spark/target/hbase-spark-1.0.1-SNAPSHOT.jar"
+
+      #   # This repository only works for cloudera clusters
+      #   # wget https://archive.cloudera.com/p/HDP/2.x/2.6.3.0/${distribution}/hdp.list -O /etc/apt/sources.list.d/hdp.list
+
+      #   retry_command "apt-get update" || err 'Unable to update packages lists.'
+      #   retry_command "apt-get install -y ${DEPENDENCIES}" || err 'Unable to install dependencies.'
+
+      #   cd $tmp_dir
+      #   git clone https://github.com/apache/hbase-connectors.git
+      #   cd hbase-connectors
+      #   # These versions are from https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.1
+      #   # except hbase, which is the maximal stable version from https://hbase.apache.org/downloads.html
+      #   mvn -Dspark.version=3.3.2 \
+      #     -Dscala.version=2.12.14 \
+      #     -Dhadoop-three.version=3.3.3 \
+      #     -Dscala.binary.version=2.12 \
+      #     -Dhbase.version=2.5.5-hadoop3 \
+      #     clean install \
+      #     -DskipTests
+      #   cp "${HBASE_SPARK_JAR}" /usr/lib/spark/
+
+      #   # clean up a bit
+      #   mvn dependency:purge-local-repository
+      #   apt-get remove -y maven
+      #   apt-get clean
+        ;;
+      "*")
+        echo "unsupported DATAPROC_IMAGE_VERSION: ${DATAPROC_IMAGE_VERSION}" >&2
+        exit 1
+        ;;
+    esac
   else
     retry_command "yum -y update" || err 'Unable to update packages lists.'
     retry_command "yum -y install hbase" || err 'Unable to install HBase.'
   fi
+}
 
-  if [[ ${DATAPROC_VERSION%%.*} -ge 2 ]]; then
-    install_bigtable_client "$BIGTABLE_HBASE_CLIENT_2X_JAR" "$BIGTABLE_HBASE_CLIENT_2X_URL" || err 'Unable to install big table client.'
-  else
-    install_bigtable_client "$BIGTABLE_HBASE_CLIENT_1X_JAR" "$BIGTABLE_HBASE_CLIENT_1X_URL" || err 'Unable to install big table client.'
+function main() {
 
+  # Install HBASE
+  install_hbase || err 'Failed to install HBase.'
+  install_bigtable_client || err 'Unable to install big table client.'
+
+  if [[ ${DATAPROC_IMAGE_VERSION%%.*} -lt 2 ]]; then
     install_shc || err 'Failed to install Spark-HBase connector.'
   fi
 

--- a/bigtable/run_hbase_commands.py
+++ b/bigtable/run_hbase_commands.py
@@ -3,6 +3,7 @@
 import subprocess
 import datetime
 import requests
+import time
 
 #import google.auth.transport.requests
 import requests
@@ -13,9 +14,16 @@ from google.cloud import bigtable
 from google.cloud.bigtable import column_family
 from google.cloud.bigtable import row_filters
 
+#table_id='test-bigtable-'+str(int(time.time()))
+table_id='test-bigtable-1695844085'
+
+MDSV1_PFX='http://metadata.google.internal/computeMetadata/v1/'
+INIT_ACTION_DOC_LINK='https://github.com/GoogleCloudDataproc/' + \
+    'initialization-actions/tree/master/bigtable#using-this-initialization-action'
+
 def create_commands_file():
-    command_string = """
-create 'test-bigtable', 'cf'
+    command_format = """
+create '{}', 'cf'
 list 'test-bigtable'
 put 'test-bigtable', 'row1', 'cf:a', 'value1'
 put 'test-bigtable', 'row2', 'cf:b', 'value2'
@@ -24,11 +32,11 @@ put 'test-bigtable', 'row4', 'cf:d', 'value4'
 exit
 """
     with open("commands.txt", "w+") as file:
-        file.write(command_string)
+        file.write(command_format.format( table_id ))
 
 def main():
     create_commands_file()
-#    subprocess.check_output(['hbase', "shell", 'commands.txt'])
+    subprocess.check_output(['hbase', "shell", 'commands.txt'])
 
     # install bigtable python client libraries
     # https://cloud.google.com/bigtable/docs/samples-python-hello#using-cloud-library
@@ -37,32 +45,44 @@ def main():
                              'google-cloud-core==2.3.2'
                              ])
 
-    # here we will verify that bigtable was updated
-    # https://cloud.google.com/bigtable/docs/samples-python-hello
-    # The client must be created with admin=True because it will create a
-    # table.
-#    scopes=['https://www.googleapis.com/auth/cloud-platform']
-
-#    credentials = service_account.Credentials \
-#                                 .with_scopes(scopes)
-#    auth_req = google.auth.transport.requests.Request()
-#    credentials.refresh(auth_req)
-
+    # curl -H "Metadata-Flavor: Google" \
+    #     http://metadata.google.internal/computeMetadata/v1/project/project-id
     s = requests.Session()
     s.headers.update({"Metadata-Flavor": "Google"})
-    # curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id
-    r = s.get('http://metadata.google.internal/computeMetadata/v1/project/project-id')
+    r = s.get(MDSV1_PFX + 'project/project-id')
 
     if r.status_code != 200:
         print("failed to request project ID")
         exit( 1 )
-    client = bigtable.Client(project=r.text, admin=True)
-    r = s.get('http://metadata.google.internal/computeMetadata/v1/instance/attributes/bigtable-instance')
-    if r.status_code != 200:
-        print("failed to request bigtable-instance attribute ; https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/bigtable#using-this-initialization-action?")
-        exit( 1 )
-    instance = client.instance(r.text)
 
+    project_id=r.text
+
+    # curl -H "Metadata-Flavor: Google" \
+    #     http://metadata.google.internal/.../instance/attributes/bigtable-instance
+    r = s.get(MDSV1_PFX + 'instance/attributes/bigtable-instance')
+    if r.status_code != 200:
+        print( "failed to determine bigtable-instance attribute\n"+
+               INIT_ACTION_DOC_LINK )
+        exit( 1 )
+
+    bigtable_instance=r.text
+
+    # here we will verify that bigtable was updated
+    # https://cloud.google.com/bigtable/docs/samples-python-hello
+
+    # The client must be created with admin=True because it will
+    # clean up the table hbase shell created
+
+    client = bigtable.Client(project=project_id, admin=True)
+    instance = client.instance(bigtable_instance)
+
+    table = instance.table(table_id)
+
+    if not table.exists():
+        print("table does not exist")
+        exit( 1 )
+    else:
+        print("table was created by hbase shell")
 
 if __name__ == '__main__':
     main()

--- a/bigtable/run_hbase_commands.py
+++ b/bigtable/run_hbase_commands.py
@@ -1,22 +1,67 @@
 #!/usr/bin/env python
 
 import subprocess
+import datetime
+import requests
 
+#import google.auth.transport.requests
+import requests
+import json
+
+#from google.oauth2 import service_account
+from google.cloud import bigtable
+from google.cloud.bigtable import column_family
+from google.cloud.bigtable import row_filters
 
 def create_commands_file():
+    command_string = """
+create 'test-bigtable', 'cf'
+list 'test-bigtable'
+put 'test-bigtable', 'row1', 'cf:a', 'value1'
+put 'test-bigtable', 'row2', 'cf:b', 'value2'
+put 'test-bigtable', 'row3', 'cf:c', 'value3'
+put 'test-bigtable', 'row4', 'cf:d', 'value4'
+exit
+"""
     with open("commands.txt", "w+") as file:
-        file.write("create 'test-bigtable', 'cf'\n"
-                   "list 'test-bigtable'\n"
-                   "put 'test-bigtable', 'row1', 'cf:a', 'value1'\n"
-                   "put 'test-bigtable', 'row2', 'cf:b', 'value2'\n"
-                   "put 'test-bigtable', 'row3', 'cf:c', 'value3'\n"
-                   "put 'test-bigtable', 'row4', 'cf:d', 'value4'\n"
-                   "exit")
-
+        file.write(command_string)
 
 def main():
     create_commands_file()
-    subprocess.check_output(['hbase', "shell", 'commands.txt'])
+#    subprocess.check_output(['hbase', "shell", 'commands.txt'])
+
+    # install bigtable python client libraries
+    # https://cloud.google.com/bigtable/docs/samples-python-hello#using-cloud-library
+    subprocess.check_output(['python3', '-m', 'pip', 'install',
+                             'google-cloud-bigtable==2.17.0',
+                             'google-cloud-core==2.3.2'
+                             ])
+
+    # here we will verify that bigtable was updated
+    # https://cloud.google.com/bigtable/docs/samples-python-hello
+    # The client must be created with admin=True because it will create a
+    # table.
+#    scopes=['https://www.googleapis.com/auth/cloud-platform']
+
+#    credentials = service_account.Credentials \
+#                                 .with_scopes(scopes)
+#    auth_req = google.auth.transport.requests.Request()
+#    credentials.refresh(auth_req)
+
+    s = requests.Session()
+    s.headers.update({"Metadata-Flavor": "Google"})
+    # curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id
+    r = s.get('http://metadata.google.internal/computeMetadata/v1/project/project-id')
+
+    if r.status_code != 200:
+        print("failed to request project ID")
+        exit( 1 )
+    client = bigtable.Client(project=r.text, admin=True)
+    r = s.get('http://metadata.google.internal/computeMetadata/v1/instance/attributes/bigtable-instance')
+    if r.status_code != 200:
+        print("failed to request bigtable-instance attribute ; https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/bigtable#using-this-initialization-action?")
+        exit( 1 )
+    instance = client.instance(r.text)
 
 
 if __name__ == '__main__':

--- a/livy/README.md
+++ b/livy/README.md
@@ -25,7 +25,7 @@ Livy installed:
     ```
 
 1.  To change installed Livy version, use `livy-version` metadata value:
-    
+
     ```bash
     REGION=<region>
     CLUSTER_NAME=<cluster_name>
@@ -35,8 +35,19 @@ Livy installed:
         --metadata livy-version=0.7.0
     ```
 
+1.  To change version of scala against which livy is linked, use `scala-version` metadata value:
+
+    ```bash
+    REGION=<region>
+    CLUSTER_NAME=<cluster_name>
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --region ${REGION} \
+        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/livy/livy.sh \
+        --metadata scala-version=2.12
+    ```
+
 1.  To change timeout for Livy session, use `livy-timeout-session` metadata value:
-    
+
     ```bash
     REGION=<region>
     CLUSTER_NAME=<cluster_name>

--- a/livy/livy.sh
+++ b/livy/livy.sh
@@ -14,9 +14,24 @@
 
 set -euxo pipefail
 
-readonly LIVY_VERSION=$(/usr/share/google/get_metadata_value attributes/livy-version || echo 0.7.0)
-readonly LIVY_PKG_NAME=apache-livy-${LIVY_VERSION}-incubating-bin
-readonly LIVY_URL=https://archive.apache.org/dist/incubator/livy/${LIVY_VERSION}-incubating/${LIVY_PKG_NAME}.zip
+# Detect dataproc image version from its various names
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
+  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
+fi
+
+if [[ $(echo "${DATAPROC_IMAGE_VERSION} >= 2.1" | bc -l) == 1  ]]; then
+  readonly LIVY_DEFAULT_VERSION="0.8.0"
+  readonly SCALA_DEFAULT_VERSION="2.12"
+else
+  readonly LIVY_DEFAULT_VERSION="0.7.1"
+  readonly SCALA_DEFAULT_VERSION="2.11"
+fi
+
+readonly LIVY_VERSION=$(/usr/share/google/get_metadata_value attributes/livy-version || echo ${LIVY_DEFAULT_VERSION})
+readonly SCALA_VERSION=$(/usr/share/google/get_metadata_value attributes/scala-version || echo ${SCALA_DEFAULT_VERSION})
+readonly LIVY_PKG_NAME="apache-livy-${LIVY_VERSION}-incubating_${SCALA_VERSION}-bin"
+readonly LIVY_BASENAME="${LIVY_PKG_NAME}.zip"
+readonly LIVY_URL="https://archive.apache.org/dist/incubator/livy/${LIVY_VERSION}-incubating/${LIVY_BASENAME}"
 readonly LIVY_TIMEOUT_SESSION=$(/usr/share/google/get_metadata_value attributes/livy-timeout-session || echo 1h)
 
 readonly LIVY_DIR=/usr/local/lib/livy


### PR DESCRIPTION
* update Copyright notice
* update the name of the dataproc image version variable
* update BIGTABLE_HBASE_CLIENT_1X_VERSION to '1.29.2'
* update BIGTABLE_HBASE_CLIENT_2X_REPO to "https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x"
* update BIGTABLE_HBASE_CLIENT_2X_VERSION to '2.7.4'
* update BIGTABLE_HBASE_CLIENT_2X_JAR to "bigtable-hbase-2.x-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
* Specifying HBASE_VERSION as "2.4.17"
* install_bigtable_client need not accept arguments
* refactor hbase installation steps into install_hbase
* add hbase installation steps for 2.1 clusters