### PR TITLE
[livy] Update livy init action to use latest release

### DIFF
--- a/livy/README.md
+++ b/livy/README.md
@@ -25,7 +25,7 @@ Livy installed:
     ```
 
 1.  To change installed Livy version, use `livy-version` metadata value:
-    
+
     ```bash
     REGION=<region>
     CLUSTER_NAME=<cluster_name>
@@ -35,8 +35,19 @@ Livy installed:
         --metadata livy-version=0.7.0
     ```
 
+1.  To change version of scala against which livy is linked, use `scala-version` metadata value:
+
+    ```bash
+    REGION=<region>
+    CLUSTER_NAME=<cluster_name>
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --region ${REGION} \
+        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/livy/livy.sh \
+        --metadata scala-version=2.12
+    ```
+
 1.  To change timeout for Livy session, use `livy-timeout-session` metadata value:
-    
+
     ```bash
     REGION=<region>
     CLUSTER_NAME=<cluster_name>

--- a/livy/livy.sh
+++ b/livy/livy.sh
@@ -14,9 +14,24 @@
 
 set -euxo pipefail
 
-readonly LIVY_VERSION=$(/usr/share/google/get_metadata_value attributes/livy-version || echo 0.7.0)
-readonly LIVY_PKG_NAME=apache-livy-${LIVY_VERSION}-incubating-bin
-readonly LIVY_URL=https://archive.apache.org/dist/incubator/livy/${LIVY_VERSION}-incubating/${LIVY_PKG_NAME}.zip
+# Detect dataproc image version from its various names
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
+  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
+fi
+
+if [[ $(echo "${DATAPROC_IMAGE_VERSION} >= 2.1" | bc -l) == 1  ]]; then
+  readonly LIVY_DEFAULT_VERSION="0.8.0"
+  readonly SCALA_DEFAULT_VERSION="2.12"
+else
+  readonly LIVY_DEFAULT_VERSION="0.7.1"
+  readonly SCALA_DEFAULT_VERSION="2.11"
+fi
+
+readonly LIVY_VERSION=$(/usr/share/google/get_metadata_value attributes/livy-version || echo ${LIVY_DEFAULT_VERSION})
+readonly SCALA_VERSION=$(/usr/share/google/get_metadata_value attributes/scala-version || echo ${SCALA_DEFAULT_VERSION})
+readonly LIVY_PKG_NAME="apache-livy-${LIVY_VERSION}-incubating_${SCALA_VERSION}-bin"
+readonly LIVY_BASENAME="${LIVY_PKG_NAME}.zip"
+readonly LIVY_URL="https://archive.apache.org/dist/incubator/livy/${LIVY_VERSION}-incubating/${LIVY_BASENAME}"
 readonly LIVY_TIMEOUT_SESSION=$(/usr/share/google/get_metadata_value attributes/livy-timeout-session || echo 1h)
 
 readonly LIVY_DIR=/usr/local/lib/livy


### PR DESCRIPTION
Latest release of livy breaks the binary distributions into those linked against scala 2.11 and those against 2.12

This update takes this change into account

This change also installs to Dataproc 2.1+ images