### PR TITLE
[bigtable] Update to work with 2.0+

### DIFF
--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -37,12 +37,9 @@ readonly BIGTABLE_HBASE_CLIENT_1X_JAR="bigtable-hbase-1.x-hadoop-${BIGTABLE_HBAS
 readonly BIGTABLE_HBASE_CLIENT_1X_URL="${BIGTABLE_HBASE_CLIENT_1X_REPO}/${BIGTABLE_HBASE_CLIENT_1X_VERSION}/${BIGTABLE_HBASE_CLIENT_1X_JAR}"
 
 readonly BIGTABLE_HBASE_CLIENT_2X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x-hadoop"
-#readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.7.4'
-readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.3.6'
+readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.12.0'
 readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-hadoop-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_2X_URL="${BIGTABLE_HBASE_CLIENT_2X_REPO}/${BIGTABLE_HBASE_CLIENT_2X_VERSION}/${BIGTABLE_HBASE_CLIENT_2X_JAR}"
-
-readonly HBASE_VERSION="2.3.6"
 
 readonly SCH_REPO="https://repo.hortonworks.com/content/groups/public/com/hortonworks"
 readonly SHC_VERSION='1.1.1-2.1-s_2.11'
@@ -219,6 +216,7 @@ function install_hbase() {
         # * client-bin
         # * bin
         echo "preparing to install hbase"
+        local HBASE_VERSION="2.3.6"
         local VARIANT="bin"
         local BASENAME="hbase-${HBASE_VERSION}-${VARIANT}.tar.gz"
         echo "hbase dist basename: ${BASENAME}"
@@ -232,7 +230,7 @@ function install_hbase() {
         # install hbase and hbase-config.sh into normal user $PATH
         ln -sf ${HBASE_HOME}/bin/hbase /usr/bin/
         ln -sf ${HBASE_HOME}/bin/hbase-config.sh /usr/bin/
-
+        echo "hbase binary distribution installed"
         ;;
       "*")
         echo "unsupported DATAPROC_IMAGE_VERSION: ${DATAPROC_IMAGE_VERSION}" >&2

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -135,6 +135,20 @@ EOF
 }
 
 function configure_bigtable_client_2x() {
+
+  case "${DATAPROC_IMAGE_VERSION}" in
+    "2.0" )
+      BIGTABLE_REGISTRY_CLASS="BigtableAsyncRegistry"
+      ;;
+    "2.1" | "2.2" )
+      BIGTABLE_REGISTRY_CLASS="BigtableConnectionsRegistry"
+      ;;
+    "*")
+      echo "unsupported DATAPROC_IMAGE_VERSION: ${DATAPROC_IMAGE_VERSION}" >&2
+      exit 1
+      ;;
+  esac
+
   local -r hbase_config=$(mktemp /tmp/hbase-site.xml-XXXX)
   cat <<EOF >${hbase_config}
 <?xml version="1.0"?>
@@ -148,7 +162,7 @@ function configure_bigtable_client_2x() {
   </property>
   <property>
     <name>hbase.client.registry.impl</name>
-    <value>org.apache.hadoop.hbase.client.BigtableConnectionsRegistry</value>
+    <value>org.apache.hadoop.hbase.client.${BIGTABLE_REGISTRY_CLASS}</value>
   </property>
   <property>
     <name>hbase.client.async.connection.impl</name>

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -76,7 +76,7 @@ function err() {
 }
 
 function install_bigtable_client() {
-  if [[ ${DATAPROC_IMAGE_VERSION%%.*} -ge 2 ]]; then
+  if [[ $(echo "${DATAPROC_IMAGE_VERSION} > 2.0" | bc -l) == 1 ]]; then
     local -r bigtable_hbase_client_jar="$BIGTABLE_HBASE_CLIENT_2X_JAR"
     local -r bigtable_hbase_client_url="$BIGTABLE_HBASE_CLIENT_2X_URL"
   else

--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#    Copyright 2018 Google, Inc.
+#    Copyright 2018,2023 Google LLC
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,17 +21,28 @@ set -euxo pipefail
 # Use Python from /usr/bin instead of /opt/conda.
 export PATH=/usr/bin:$PATH
 
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+
+# Detect dataproc image version from its various names
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
+  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
+fi
+
 readonly HBASE_HOME='/usr/lib/hbase'
+mkdir -p "${HBASE_HOME}/{lib,conf,logs}"
 
 readonly BIGTABLE_HBASE_CLIENT_1X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-1.x-hadoop"
-readonly BIGTABLE_HBASE_CLIENT_1X_VERSION='1.26.1'
+readonly BIGTABLE_HBASE_CLIENT_1X_VERSION='1.29.2'
 readonly BIGTABLE_HBASE_CLIENT_1X_JAR="bigtable-hbase-1.x-hadoop-${BIGTABLE_HBASE_CLIENT_1X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_1X_URL="${BIGTABLE_HBASE_CLIENT_1X_REPO}/${BIGTABLE_HBASE_CLIENT_1X_VERSION}/${BIGTABLE_HBASE_CLIENT_1X_JAR}"
 
-readonly BIGTABLE_HBASE_CLIENT_2X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x-hadoop"
-readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='1.26.1'
-readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-hadoop-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
+readonly BIGTABLE_HBASE_CLIENT_2X_REPO="https://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-2.x"
+readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.7.4'
+#readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.3.6'
+readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_2X_URL="${BIGTABLE_HBASE_CLIENT_2X_REPO}/${BIGTABLE_HBASE_CLIENT_2X_VERSION}/${BIGTABLE_HBASE_CLIENT_2X_JAR}"
+
+readonly HBASE_VERSION="2.3.6"
 
 readonly SCH_REPO="https://repo.hortonworks.com/content/groups/public/com/hortonworks"
 readonly SHC_VERSION='1.1.1-2.1-s_2.11'
@@ -41,6 +52,10 @@ readonly SHC_URL="${SCH_REPO}/shc-core/${SHC_VERSION}/${SHC_JAR}"
 readonly SHC_EXAMPLES_URL="${SCH_REPO}/shc-examples/${SHC_VERSION}/${SHC_EXAMPLES_JAR}"
 
 readonly BIGTABLE_INSTANCE="$(/usr/share/google/get_metadata_value attributes/bigtable-instance)"
+if [[ -z "${BIGTABLE_INSTANCE}" ]]; then
+  echo "failed to determine bigtable-instance attribute ; https://github.com/GoogleCloudDataproc/initialization-actions/tree/master/bigtable#using-this-initialization-action"
+  exit 1
+fi
 readonly BIGTABLE_PROJECT="$(/usr/share/google/get_metadata_value attributes/bigtable-project ||
     /usr/share/google/get_metadata_value ../project/project-id)"
 
@@ -61,8 +76,14 @@ function err() {
 }
 
 function install_bigtable_client() {
-  local -r bigtable_hbase_client_jar="$1"
-  local -r bigtable_hbase_client_url="$2"
+  if [[ ${DATAPROC_IMAGE_VERSION%%.*} -ge 2 ]]; then
+    local -r bigtable_hbase_client_jar="$BIGTABLE_HBASE_CLIENT_2X_JAR"
+    local -r bigtable_hbase_client_url="$BIGTABLE_HBASE_CLIENT_2X_URL"
+  else
+    local -r bigtable_hbase_client_jar="$BIGTABLE_HBASE_CLIENT_1X_JAR"
+    local -r bigtable_hbase_client_url="$BIGTABLE_HBASE_CLIENT_1X_URL"
+  fi
+
   local out="${HBASE_HOME}/lib/${bigtable_hbase_client_jar}"
   wget -nv --timeout=30 --tries=5 --retry-connrefused \
     "${bigtable_hbase_client_url}" -O "${out}"
@@ -103,10 +124,14 @@ EOF
 </configuration>
 EOF
 
-  bdconfig merge_configurations \
-    --configuration_file "${HBASE_HOME}/conf/hbase-site.xml" \
-    --source_configuration_file "$hbase_config" \
-    --clobber
+  if [[ -f "${HBASE_HOME}/conf/hbase-site.xml" ]]; then
+    bdconfig merge_configurations \
+      --configuration_file "${HBASE_HOME}/conf/hbase-site.xml" \
+      --source_configuration_file "$hbase_config" \
+      --clobber
+  else
+    cp "$hbase_config" "${HBASE_HOME}/conf/hbase-site.xml"
+  fi
 }
 
 function configure_bigtable_client_2x() {
@@ -123,7 +148,7 @@ function configure_bigtable_client_2x() {
   </property>
   <property>
     <name>hbase.client.registry.impl</name>
-    <value>org.apache.hadoop.hbase.client.BigtableAsyncRegistry</value>
+    <value>org.apache.hadoop.hbase.client.BigtableConnectionsRegistry</value>
   </property>
   <property>
     <name>hbase.client.async.connection.impl</name>
@@ -135,10 +160,15 @@ function configure_bigtable_client_2x() {
 </configuration>
 EOF
 
-  bdconfig merge_configurations \
-    --configuration_file "${HBASE_HOME}/conf/hbase-site.xml" \
-    --source_configuration_file "$hbase_config" \
-    --clobber
+  if [[ -f "${HBASE_HOME}/conf/hbase-site.xml" ]]; then
+    bdconfig merge_configurations \
+      --configuration_file "${HBASE_HOME}/conf/hbase-site.xml" \
+      --source_configuration_file "$hbase_config" \
+      --clobber
+  else
+    cp "$hbase_config" "${HBASE_HOME}/conf/hbase-site.xml"
+  fi
+
 }
 
 function configure_bigtable_client() {
@@ -155,30 +185,81 @@ SPARK_DIST_CLASSPATH="${SPARK_DIST_CLASSPATH}:/usr/lib/hbase/lib/*"
 SPARK_DIST_CLASSPATH="${SPARK_DIST_CLASSPATH}:/etc/hbase/conf"
 EOF
 
-  if [[ ${DATAPROC_VERSION%%.*} -ge 2 ]]; then
+  if [[ ${DATAPROC_IMAGE_VERSION%%.*} -ge 2 ]]; then
     configure_bigtable_client_2x || err 'Failed to configure big table 2.x client.'
   else
     configure_bigtable_client_1x || err 'Failed to configure big table 1.x client.'
   fi
 }
 
-function main() {
+function install_hbase() {
   if command -v apt-get >/dev/null; then
-    retry_command "apt-get update" || err 'Unable to update packages lists.'
-    retry_command "apt-get install -y hbase" || err 'Unable to install HBase.'
+    case "${DATAPROC_IMAGE_VERSION}" in
+      "1.3" | "1.4" | "1.5" | "2.0" )
+
+        # On images prior to Dataproc 2.1, hbase can be installed from Google's bigtop repositories
+        retry_command "apt-get update" || err 'Unable to update packages lists.'
+        retry_command "apt-get install -y hbase" || err 'Unable to install HBase.'
+        ;;
+
+      "2.1" | "2.2" )
+
+        # get hbase tar from official site
+        # Variants:
+        # * hadoop3-client-bin
+        # * hadoop3-bin
+        # * client-bin
+        # * bin
+        echo "preparing to install hbase"
+        local VARIANT="bin"
+        local BASENAME="hbase-${HBASE_VERSION}-${VARIANT}.tar.gz"
+        echo "hbase dist basename: ${BASENAME}"
+        wget "https://archive.apache.org/dist/hbase/${HBASE_VERSION}/${BASENAME}" -P /tmp || err 'Unable to download tar'
+
+        # extract binaries from bundle
+        mkdir -p "/tmp/hbase-${HBASE_VERSION}/" "${HBASE_HOME}"
+        tar xzf "/tmp/${BASENAME}" --strip-components=1 -C "/tmp/hbase-${HBASE_VERSION}/"
+        cp -a "/tmp/hbase-${HBASE_VERSION}/." "${HBASE_HOME}/"
+
+        # prune incompatible jars
+        INCOMPATIBLE_JARS="guava protobuf-java"
+        for pkg in ${INCOMPATIBLE_JARS} ; do
+          find ${HBASE_HOME}/lib -name "$pkg-*.jar" -delete
+        done
+
+        # include jars with expected symbols
+        MVN_PFX="https://repo1.maven.org/maven2"
+        for url in \
+          "${MVN_PFX}/com/google/cloud/bigtable/bigtable-hbase-2.x-hadoop/2.7.4/bigtable-hbase-2.x-hadoop-2.7.4.jar" \
+          "${MVN_PFX}/com/google/cloud/google-cloud-bigtable/2.20.4/google-cloud-bigtable-2.20.4.jar" \
+          "${MVN_PFX}/com/google/api/grpc/proto-google-cloud-bigtable-admin-v2/2.20.4/proto-google-cloud-bigtable-admin-v2-2.20.4.jar" \
+          "${MVN_PFX}/com/google/protobuf/protobuf-java/3.23.0/protobuf-java-3.23.0.jar" \
+          "${MVN_PFX}/net/bytebuddy/byte-buddy/1.14.8/byte-buddy-1.14.8.jar" \
+          "${MVN_PFX}/org/threeten/threetenbp/1.6.8/threetenbp-1.6.8.jar"
+        do
+          wget -P "${HBASE_HOME}/lib" ${url}
+        done
+
+        # install hbase and hbase-config.sh into normal user $PATH
+        ln -sf ${HBASE_HOME}/bin/hbase /usr/bin/
+        ln -sf ${HBASE_HOME}/bin/hbase-config.sh /usr/bin/
+
+        ;;
+      "*")
+        echo "unsupported DATAPROC_IMAGE_VERSION: ${DATAPROC_IMAGE_VERSION}" >&2
+        exit 1
+        ;;
+    esac
   else
     retry_command "yum -y update" || err 'Unable to update packages lists.'
     retry_command "yum -y install hbase" || err 'Unable to install HBase.'
   fi
+}
 
-  if [[ ${DATAPROC_VERSION%%.*} -ge 2 ]]; then
-    install_bigtable_client "$BIGTABLE_HBASE_CLIENT_2X_JAR" "$BIGTABLE_HBASE_CLIENT_2X_URL" || err 'Unable to install big table client.'
-  else
-    install_bigtable_client "$BIGTABLE_HBASE_CLIENT_1X_JAR" "$BIGTABLE_HBASE_CLIENT_1X_URL" || err 'Unable to install big table client.'
-
-    install_shc || err 'Failed to install Spark-HBase connector.'
-  fi
-
+function main() {
+  install_hbase             || err 'Failed to install HBase.'
+  install_bigtable_client   || err 'Unable to install big table client.'
+  install_shc               || err 'Failed to install Spark-HBase connector.'
   configure_bigtable_client || err 'Failed to configure big table client.'
 }
 

--- a/bigtable/test_bigtable.py
+++ b/bigtable/test_bigtable.py
@@ -68,9 +68,6 @@ class BigTableTestCase(DataprocTestCase):
         ("HA", ["m-0"]),
     )
     def test_bigtable(self, configuration, machine_suffixes):
-        if self.getImageVersion() < pkg_resources.parse_version("2.0") and self.getImageOs() == "rocky":
-            self.skipTest("Not supported in pre 2.0 or Rocky images")
-
         self.createCluster(
             configuration, self.INIT_ACTIONS, metadata=self.metadata)
 

--- a/bigtable/test_bigtable.py
+++ b/bigtable/test_bigtable.py
@@ -68,6 +68,9 @@ class BigTableTestCase(DataprocTestCase):
         ("HA", ["m-0"]),
     )
     def test_bigtable(self, configuration, machine_suffixes):
+        if self.getImageOs() == 'rocky':
+            self.skipTest("Not supported in Rocky Linux-based images")
+
         self.createCluster(
             configuration, self.INIT_ACTIONS, metadata=self.metadata)
 

--- a/bigtable/test_bigtable.py
+++ b/bigtable/test_bigtable.py
@@ -68,8 +68,8 @@ class BigTableTestCase(DataprocTestCase):
         ("HA", ["m-0"]),
     )
     def test_bigtable(self, configuration, machine_suffixes):
-        if self.getImageOs() == 'rocky':
-            self.skipTest("Not supported in Rocky Linux-based images")
+        if self.getImageVersion() < pkg_resources.parse_version("2.0") and self.getImageOs() == "rocky":
+            self.skipTest("Not supported in pre 2.0 or Rocky images")
 
         self.createCluster(
             configuration, self.INIT_ACTIONS, metadata=self.metadata)


### PR DESCRIPTION
* updated copyright date
* set variables distribution and DATAPROC_IMAGE_VERSION
* updated BIGTABLE_HBASE_CLIENT_1X_VERSION to latest, '1.29.2'
* corrected and tested BIGTABLE_HBASE_CLIENT_2X_* variables
* specifying HBASE_VERSION="2.3.6"
* ensured that BIGTABLE_INSTANCE metadata variable is supplied
* simplified call to install_bigtable_client to remove requirement for arguments
* Create "${HBASE_HOME}/conf/hbase-site.xml" if not exist
* corrected hbase.client.registry.impl to org.apache.hadoop.hbase.client.BigtableConnectionsRegistry
* renamed DATAPROC_VERSION variable to DATAPROC_IMAGE_VERSION
* moved hbase installation logic out of function main into a new function install_hbase
* using hbase apt-get logic only for dataproc versions < 2.1
* developed new hbase installation logic for dataproc versions >= 2.1
* reporting to customer when installation to unsupported version of dataproc is attempted