### PR TITLE
[zeppelin] corrected DATAPROC_VERSION to DATAPROC_IMAGE_VERSION

### DIFF
--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -26,7 +26,7 @@ fi
 
 
 readonly NOT_SUPPORTED_MESSAGE="Zeppelin initialization action is not supported on Dataproc ${DATAPROC_IMAGE_VERSION}.
-Use Zeppelin Component instead: https://cloud.google.com/dataproc/docs/concepts/components/zeppelin"
+Use Zeppelin Optional Component instead: https://cloud.google.com/dataproc/docs/concepts/components/zeppelin"
 [[ "${DATAPROC_IMAGE_VERSION}" != 1.* ]] && echo "${NOT_SUPPORTED_MESSAGE}" && exit 1
 
 readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"

--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -19,9 +19,15 @@
 
 set -euxo pipefail
 
-readonly NOT_SUPPORTED_MESSAGE="Zeppelin initialization action is not supported on Dataproc ${DATAPROC_VERSION}.
+# Detect dataproc image version from its various names
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_IMAGE_VERSION; then
+  DATAPROC_IMAGE_VERSION="${DATAPROC_IMAGE_VERSION}"
+fi
+
+
+readonly NOT_SUPPORTED_MESSAGE="Zeppelin initialization action is not supported on Dataproc ${DATAPROC_IMAGE_VERSION}.
 Use Zeppelin Component instead: https://cloud.google.com/dataproc/docs/concepts/components/zeppelin"
-[[ $DATAPROC_VERSION != 1.* ]] && echo "$NOT_SUPPORTED_MESSAGE" && exit 1
+[[ $DATAPROC_IMAGE_VERSION != 1.* ]] && echo "$NOT_SUPPORTED_MESSAGE" && exit 1
 
 readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'

--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -20,14 +20,14 @@
 set -euxo pipefail
 
 # Detect dataproc image version from its various names
-if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_IMAGE_VERSION; then
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
   DATAPROC_IMAGE_VERSION="${DATAPROC_IMAGE_VERSION}"
 fi
 
 
 readonly NOT_SUPPORTED_MESSAGE="Zeppelin initialization action is not supported on Dataproc ${DATAPROC_IMAGE_VERSION}.
 Use Zeppelin Component instead: https://cloud.google.com/dataproc/docs/concepts/components/zeppelin"
-[[ $DATAPROC_IMAGE_VERSION != 1.* ]] && echo "$NOT_SUPPORTED_MESSAGE" && exit 1
+[[ "${DATAPROC_IMAGE_VERSION}" != 1.* ]] && echo "${NOT_SUPPORTED_MESSAGE}" && exit 1
 
 readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'
@@ -72,8 +72,8 @@ function install_zeppelin() {
   local asm_3_1=/usr/lib/zeppelin/lib/asm-3.1.jar
   local asm_5_0_4=/usr/lib/zeppelin/lib/asm-5.0.4.jar
 
-  if [[ "$zeppelin_version" == "0.7."* && -f "$asm_3_1" && -f "$asm_5_0_4" ]]; then
-    rm "$asm_5_0_4"
+  if [[ "${zeppelin_version}" == "0.7."* && -f "${asm_3_1}" && -f "${asm_5_0_4}" ]]; then
+    rm "${asm_5_0_4}"
   fi
 }
 

--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -21,7 +21,7 @@ set -euxo pipefail
 
 # Detect dataproc image version from its various names
 if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
-  DATAPROC_IMAGE_VERSION="${DATAPROC_IMAGE_VERSION}"
+  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
 fi
 
 


### PR DESCRIPTION
This will not make zeppelin work on 2.1 image, instead users should use  --optional-components=ZEPPELIN