### PR TITLE
Improving the init action test for Kafka

### DIFF
--- a/integration_tests/dataproc_test_case.py
+++ b/integration_tests/dataproc_test_case.py
@@ -105,7 +105,7 @@ class DataprocTestCase(parameterized.TestCase):
         self.cluster_zone = zone
 
         init_actions = [
-            "{}/{}".format(self.INIT_ACTIONS_REPO, i)
+            "{}/{}".format(self.INIT_ACTIONS_REPO, i) if "gs://" not in i else i
             for i in init_actions or []
         ]
 

--- a/kafka/BUILD
+++ b/kafka/BUILD
@@ -9,11 +9,20 @@ py_test(
     data = [
         "kafka.sh",
         "validate.sh",
+        "cruise-control.sh",
+        "kafka-manager.sh",
     ],
     local = True,
     shard_count = 1,
     deps = [
+        ":verify_kafka_running",
         "//integration_tests:dataproc_test_case",
         "@io_abseil_py//absl/testing:parameterized",
     ],
+)
+
+py_library(
+    name = "verify_kafka_running",
+    testonly = True,
+    srcs = ["verify_kafka_running.py"],
 )

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -19,6 +19,7 @@ You can use this initialization action to create a new Dataproc cluster with Kaf
         --region ${REGION} \
         --num-masters 3 \
         --metadata "run-on-master=true" \
+        --metadata "install-kafka-python=true" \
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/kafka/kafka.sh
     ```
 1. You can test your Kafka setup by creating a simple topic and publishing to it with Kafka's command-line tools, after SSH'ing into one of your nodes:
@@ -59,6 +60,7 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
     --num-masters 3 \
     --metadata "run-on-master=true" \
     --metadata "kafka-enable-jmx=true" \
+    --metadata "install-kafka-python=true" \
     --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/kafka/kafka.sh,gs://goog-dataproc-initialization-actions-${REGION}/kafka/kafka-manager.sh
 ```
 
@@ -73,6 +75,7 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
     --region ${REGION} \
     --num-masters 3 \
     --metadata "run-on-master=true" \
+    --metadata "install-kafka-python=true" \
     --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/kafka/kafka.sh,gs://goog-dataproc-initialization-actions-${REGION}/kafka/cruise-control.sh
 ```
 
@@ -88,6 +91,7 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
     --num-masters 3 \
     --metadata "run-on-master=true" \
     --metadata "prometheus-http-port=9096" \
+    --metadata "install-kafka-python=true" \
     --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/kafka/kafka.sh,gs://goog-dataproc-initialization-actions-${REGION}/prometheus/prometheus.sh
 ```
 

--- a/kafka/kafka.sh
+++ b/kafka/kafka.sh
@@ -25,6 +25,7 @@ readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
 readonly RUN_ON_MASTER="$(/usr/share/google/get_metadata_value attributes/run-on-master || echo false)"
 readonly KAFKA_ENABLE_JMX="$(/usr/share/google/get_metadata_value attributes/kafka-enable-jmx || echo false)"
 readonly KAFKA_JMX_PORT="$(/usr/share/google/get_metadata_value attributes/kafka-jmx-port || echo 9999)"
+readonly INSTALL_KAFKA_PYTHON="$(/usr/share/google/get_metadata_value attributes/install-kafka-python || echo false)"
 
 # The first ZooKeeper server address, e.g., "cluster1-m-0:2181".
 ZOOKEEPER_ADDRESS=''
@@ -40,6 +41,11 @@ function retry_apt_command() {
     sleep 5
   done
   return 1
+}
+
+function recv_keys() {
+  retry_apt_command "apt-get install -y gnupg2 &&\
+                     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C"
 }
 
 function update_apt_get() {
@@ -168,8 +174,29 @@ function install_and_configure_kafka_server() {
   wait_for_kafka
 }
 
+function install_kafka_python_package() {
+  KAFKA_PYTHON_PACKAGE="kafka-python==2.0.2"
+  if [[ "${INSTALL_KAFKA_PYTHON}" != "true" ]]; then
+    return
+  fi
+
+  if [[ "$(echo "${DATAPROC_IMAGE_VERSION} > 2.0" | bc)" -eq 1 ]]; then
+    /opt/conda/default/bin/pip install "${KAFKA_PYTHON_PACKAGE}" || { sleep 10; /opt/conda/default/bin/pip install "${KAFKA_PYTHON_PACKAGE}"; }
+  else
+    OS=$(. /etc/os-release && echo "${ID}")
+    if [[ "${OS}" == "rocky" ]]; then
+      yum install -y python2-pip
+    else
+      apt-get install -y python-pip
+    fi
+    pip2 install "${KAFKA_PYTHON_PACKAGE}" || { sleep 10; pip2 install "${KAFKA_PYTHON_PACKAGE}"; } || { sleep 10; pip install "${KAFKA_PYTHON_PACKAGE}"; }
+  fi
+}
+
 function main() {
+  recv_keys || err 'Unable to receive keys.'
   update_apt_get || err 'Unable to update packages lists.'
+  install_kafka_python_package
 
   # Only run the installation on workers; verify zookeeper on master(s).
   if [[ "${ROLE}" == 'Master' ]]; then

--- a/kafka/test_kafka.py
+++ b/kafka/test_kafka.py
@@ -1,5 +1,6 @@
 import os
 
+import pkg_resources
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -9,7 +10,12 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 class KafkaTestCase(DataprocTestCase):
     COMPONENT = 'kafka'
     INIT_ACTIONS = ['kafka/kafka.sh']
+    KAFKA_CRUISE_CONTROL_INIT_ACTION = ['kafka/kafka.sh', 'kafka/cruise-control.sh']
+    KAFKA_MANAGER_INIT_ACTION = ['kafka/kafka.sh', 'kafka/kafka-manager.sh']
     TEST_SCRIPT_FILE_NAME = 'validate.sh'
+    PYTHON2_VERSION = 'python2.7'
+    PYTHON3_VERSION = 'python3'
+    KAFKA_VERIFY_SCRIPT_PYTHON = 'verify_kafka_running.py'
 
     def verify_instance(self, name):
         self.upload_test_file(
@@ -23,16 +29,103 @@ class KafkaTestCase(DataprocTestCase):
         self.assert_instance_command(
             name, "bash {}".format(self.TEST_SCRIPT_FILE_NAME))
 
+    def __submit_pyspark_job(self, cluster_name):
+        if self.getImageVersion() >= pkg_resources.parse_version("2.1"):
+            python_version = self.PYTHON3_VERSION
+        else:
+            python_version = self.PYTHON2_VERSION
+        self.assert_dataproc_job(cluster_name, 'pyspark',
+                                 '{}/{}/{} --properties=spark.pyspark.python={},spark.pyspark.driver.python={}'
+                                 ' -- /var/lib/kafka-logs'
+                                 .format(self.INIT_ACTIONS_REPO,
+                                         self.COMPONENT,
+                                         self.KAFKA_VERIFY_SCRIPT_PYTHON,
+                                         python_version,
+                                         python_version))
+
     @parameterized.parameters(
         ("HA", ["m-0", "m-1", "m-2"]), )
     def test_kafka(self, configuration, machine_suffixes):
         if self.getImageOs() == 'rocky':
             self.skipTest("Not supported in Rocky Linux-based images")
 
-        self.createCluster(configuration, self.INIT_ACTIONS)
+        metadata = 'run-on-master=true'
+        self.createCluster(configuration, self.INIT_ACTIONS, metadata=metadata)
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),
                                                 machine_suffix))
+
+    @parameterized.parameters(
+        'STANDARD',
+        'HA',
+    )
+    def test_kafka_job(self, configuration):
+        if self.getImageOs() == 'rocky':
+            self.skipTest("Not supported in Rocky Linux-based images")
+
+        metadata = 'run-on-master=true,install-kafka-python=true'
+        properties = 'dataproc:alpha.components=ZOOKEEPER'
+        self.createCluster(configuration, self.INIT_ACTIONS, metadata=metadata,
+                           properties=properties)
+        self.__submit_pyspark_job(self.getClusterName())
+
+    @parameterized.parameters(
+        ("HA", ["m-0", "m-1", "m-2"]), )
+    def test_kafka_cruise_control(self, configuration, machine_suffixes):
+        if self.getImageOs() == 'rocky':
+            self.skipTest("Not supported in Rocky Linux-based images")
+
+        metadata = 'run-on-master=true'
+        self.createCluster(configuration, self.KAFKA_CRUISE_CONTROL_INIT_ACTION, metadata=metadata)
+        for machine_suffix in machine_suffixes:
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
+
+    @parameterized.parameters(
+        'STANDARD',
+        'HA',
+    )
+    def test_kafka_cruise_control_job(self, configuration):
+        if self.getImageOs() == 'rocky':
+            self.skipTest("Not supported in Rocky Linux-based images")
+
+        metadata = 'run-on-master=true,install-kafka-python=true'
+        properties = 'dataproc:alpha.components=ZOOKEEPER'
+        self.createCluster(configuration, self.KAFKA_CRUISE_CONTROL_INIT_ACTION, metadata=metadata,
+                           properties=properties)
+        self.__submit_pyspark_job(self.getClusterName())
+
+    @parameterized.parameters(
+        ("HA", ["m-0", "m-1", "m-2"]), )
+    def test_kafka_manager(self, configuration, machine_suffixes):
+        if self.getImageOs() == 'rocky':
+            self.skipTest("Not supported in Rocky Linux-based images")
+
+        if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
+            self.skipTest("Java 11 or higher is required for CMAK")
+
+        metadata = 'run-on-master=true, kafka-enable-jmx=true'
+        self.createCluster(configuration, self.KAFKA_MANAGER_INIT_ACTION, metadata=metadata)
+        for machine_suffix in machine_suffixes:
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
+
+    @parameterized.parameters(
+        'STANDARD',
+        'HA',
+    )
+    def test_kafka_manager_job(self, configuration):
+        if self.getImageOs() == 'rocky':
+            self.skipTest("Not supported in Rocky Linux-based images")
+
+        if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
+            self.skipTest("Java 11 or higher is required for CMAK")
+
+        metadata = 'run-on-master=true, kafka-enable-jmx=true, install-kafka-python=true'
+        properties = 'dataproc:alpha.components=ZOOKEEPER'
+        self.createCluster(configuration, self.KAFKA_MANAGER_INIT_ACTION, metadata=metadata,
+                           properties=properties)
+        self.__submit_pyspark_job(self.getClusterName())
 
 
 if __name__ == '__main__':

--- a/kafka/verify_kafka_running.py
+++ b/kafka/verify_kafka_running.py
@@ -1,0 +1,167 @@
+"""verify_kafka_running.py: Script for Kafka initialization action test.
+"""
+import os
+import sys
+import time
+
+from kafka import KafkaConsumer
+from kafka import KafkaProducer
+from kafka.errors import KafkaError
+
+TOPIC_NAME = 'test'
+NUM_MESSAGES = 10
+WORKER_0_NODE_SUFFIX = '-w-0'
+WORKER_1_NODE_SUFFIX = '-w-1'
+PORT = '9092'
+NUM_RETRIES = 3
+SLEEP_TIME_SECS = 1
+DATAPROC_IMAGE_VERSION = os.environ['DATAPROC_IMAGE_VERSION']
+
+
+def get_cluster_name():
+    """Gets full cluster name.
+
+    Returns:
+      cluster_name: full name of the cluster
+    """
+    command = ('/usr/share/google/get_metadata_value '
+               'attributes/dataproc-cluster-name')
+    with os.popen(command) as process:
+        return process.read()
+
+
+class KafkaTestRunner(object):
+    """Interfaces with Apache Kafka python client and command-line tools.
+
+    Args:
+      cluster_name (str): full cluster name of test cluster
+    """
+
+    def __init__(self, cluster_name):
+        self.cluster_name = cluster_name
+
+    def _get_address(self, node_suffix, port):
+        """Generates full address from cluster name, suffix and port.
+
+        Args:
+          node_suffix (str): node suffix
+          port (str): connection port for worker node
+
+        Returns:
+          string: address specified by node_suffix and port
+        """
+        return self.cluster_name + node_suffix + ':' + port
+
+    def create_test_topic(self):
+        """Creates topic.
+
+        Raises:
+          Exception: if topic creation is unsuccessful
+        """
+        if DATAPROC_IMAGE_VERSION >= "2.1":
+            args = ('--bootstrap-server localhost:9092 --create --replication-factor 1 '
+                    '--partitions 1 --topic %s') % TOPIC_NAME
+        else:
+            args = ('--zookeeper localhost:2181 --create --replication-factor 1 '
+                    '--partitions 1 --topic %s') % TOPIC_NAME
+        command = '/usr/lib/kafka/bin/kafka-topics.sh ' + args
+        if os.WEXITSTATUS(os.system(command)) != os.EX_OK:
+            raise Exception('Create test topic unsuccessful')
+
+    def publish_messages(self):
+        """Publishes messages using worker 0 as the broker.
+
+           Fails if publishing is unsuccessful.
+
+        Raises:
+          Exception: if publishing results in KafkaError
+        """
+        node_name = self._get_address(WORKER_0_NODE_SUFFIX, PORT)
+        print('Publishing ' + node_name)
+
+        producer = KafkaProducer(
+            bootstrap_servers=[node_name],
+            retries=NUM_RETRIES)
+
+        try:
+            for i in range(NUM_MESSAGES):
+                time.sleep(SLEEP_TIME_SECS)
+                print(i)
+                if DATAPROC_IMAGE_VERSION >= "2.1":
+                    producer.send(TOPIC_NAME, bytes('message' + str(i), 'utf-8'))
+                else:
+                    producer.send(TOPIC_NAME, 'message' + str(i))
+        except KafkaError:
+            raise Exception('Publish messages unsuccessful')
+        finally:
+            producer.flush()
+            producer.close()
+
+    def consume_messages(self):
+        """Consumes messages using worker 1 as the broker.
+
+          Fails if consuming is unsuccessful or if number of published messages does
+          not match the number of consumed messages.
+
+        Raises:
+          Exception: if consuming results in KafkaError, or mismatch in number of
+            published/consumed messages
+        """
+        node_name = self._get_address(WORKER_1_NODE_SUFFIX, PORT)
+        print('Consuming ' + node_name)
+
+        consumer = KafkaConsumer(
+            TOPIC_NAME,
+            bootstrap_servers=[node_name],
+            auto_offset_reset='smallest',
+            request_timeout_ms=120000)
+
+        try:
+            if DATAPROC_IMAGE_VERSION < "2.1":
+                consumer_iter = iter(consumer)
+
+            # ensures consumer receives all messages sent by producer
+            for _ in range(NUM_MESSAGES):
+                message = consumer_iter.next()
+                print(message.value)
+        except KafkaError:
+            raise Exception('Consume messages unsuccessful')
+        finally:
+            consumer.close()
+
+
+def parse_kafka_config():
+    config = {}
+    with open('/etc/kafka/conf/server.properties') as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                (key, value) = line.split('=', 1)
+                config[key] = value
+    print(config)
+    return config
+
+
+def verify_kafka_config():
+    config = parse_kafka_config()
+    expected_logs_dirs = sys.argv[1]
+    if config['log.dirs'] != expected_logs_dirs:
+        raise Exception('Invalid log.dirs, expected: {}, actual: {}'.format(
+            expected_logs_dirs, config['log.dirs']))
+
+
+def test_produce_and_consume_messages():
+    cluster_name = get_cluster_name()
+    kafka_runner = KafkaTestRunner(cluster_name)
+    kafka_runner.create_test_topic()
+    kafka_runner.publish_messages()
+    kafka_runner.consume_messages()
+
+
+def main():
+    verify_kafka_config()
+    test_produce_and_consume_messages()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
For Kafka, adding the tests for submission of jobs and verifying instances to increase the coverage for overall scope. The test now runs kafka jobs with cruise-control and kafka-manager. Also, adding the test for cruise-control and kafka-manager instance verification. 