### PR TITLE
[dr-elephant] Using $(hostname -s) rather than ${HOSTNAME}

### DIFF
--- a/dr-elephant/dr-elephant.sh
+++ b/dr-elephant/dr-elephant.sh
@@ -150,7 +150,7 @@ function run_dr() {
 }
 
 # Install on master node
-if [[ "${HOSTNAME}" == "${MASTER_HOSTNAME}" ]]; then
+if [[ "$(hostname -s)" == "${MASTER_HOSTNAME}" ]]; then
   build || err 'Build step failed'
   configure || err 'Configuration failed'
   prepare_mysql || err 'Could not proceed with mysql'


### PR DESCRIPTION
Recent change in the hostname implementation has required that we find short hostname using a different mechanism.  This patch makes that change.