### PR TITLE
[kafka] Using $(hostname -s) vs ${HOSTNAME}

### DIFF
--- a/kafka/cruise-control.sh
+++ b/kafka/cruise-control.sh
@@ -52,7 +52,7 @@ function build_cruise_control() {
 
 function update_kafka_metrics_reporter() {
   if [[ ! -d "${CRUISE_CONTROL_HOME}" ]]; then
-    echo "Kafka is not installed on this node ${HOSTNAME}, skip configuring Cruise Control."
+    echo "Kafka is not installed on this node $(hostname -s), skip configuring Cruise Control."
     return 0
   fi
 
@@ -100,7 +100,7 @@ function start_cruise_control_server() {
     err "Metrics topic __CruiseControlMetrics was not found in the cluster."
   fi
 
-  echo "Start Cruise Control server on ${HOSTNAME}."
+  echo "Start Cruise Control server on $(hostname -s)."
   pushd ${CRUISE_CONTROL_HOME}
   ./kafka-cruise-control-start.sh config/cruisecontrol.properties &
   popd
@@ -111,7 +111,7 @@ function main() {
   build_cruise_control
   update_kafka_metrics_reporter
   # Run CC on the first master node.
-  if [[ "${HOSTNAME}" == *-m || "${HOSTNAME}" == *-m-0 ]]; then
+  if [[ "$(hostname -s)" == *-m || "$(hostname -s)" == *-m-0 ]]; then
     configure_cruise_control_server
     start_cruise_control_server
   fi

--- a/kafka/kafka-manager.sh
+++ b/kafka/kafka-manager.sh
@@ -82,7 +82,7 @@ function configure_and_start_cmak(){
    cd /opt/"${KAFKA_MANAGER_VERSION}"
    sed -i 's/cmak.zkhosts="kafka-manager-zookeeper:2181"/cmak.zkhosts=\"'"${zkhosts}"'\"/g' conf/application.conf
 
-   echo "Starting Kafka Manager server on ${HOSTNAME}:${KAFKA_MANAGER_HTTP_PORT}."
+   echo "Starting Kafka Manager server on $(hostname -s):${KAFKA_MANAGER_HTTP_PORT}."
    ./bin/cmak -Dconfig.file=conf/application.conf -Dhttp.port="${KAFKA_MANAGER_HTTP_PORT}" &
 }
 
@@ -94,7 +94,7 @@ function main(){
       exit 1
    else
       # Run Kafka Manager on the first master node.
-      if [[ "${HOSTNAME}" == *-m || "${HOSTNAME}" == *-m-0 ]]; then
+      if [[ "$(hostname -s)" == *-m || "$(hostname -s)" == *-m-0 ]]; then
          install_packages
          add_sources
          install_sbt


### PR DESCRIPTION
Recent change in the hostname implementation has required that we find short hostname using a different mechanism.  This patch makes that change.