### PR TITLE
[ganglia] Using $(hostname -s) vs ${HOSTNAME}

### DIFF
--- a/ganglia/ganglia.sh
+++ b/ganglia/ganglia.sh
@@ -58,7 +58,7 @@ function main() {
   sed -e '/bind /s/^  /  #/' -i /etc/ganglia/gmond.conf
   sed -e "/udp_send_channel {/a\  host = ${master_hostname}" -i /etc/ganglia/gmond.conf
 
-  if [[ "${HOSTNAME}" == "${master_hostname}" ]]; then
+  if [[ "$(hostname -s)" == "${master_hostname}" ]]; then
     # Setup Ganglia host only on the master node ("0"-master in HA mode)
     setup_ganglia_host || err 'Setting up Ganglia host failed'
   else


### PR DESCRIPTION
Recent change in the hostname implementation has required that we find short hostname using a different mechanism.  This patch makes that change.