### PR TITLE
[hue] Using $(hostname -s) vs ${HOSTNAME}

### DIFF
--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -235,7 +235,7 @@ EOF
 }
 
 # Only run on the master node ("0"-master in HA mode) of the cluster
-if [[ "${HOSTNAME}" == "${MASTER_HOSTNAME}" ]]; then
+if [[ "$(hostname -s)" == "${MASTER_HOSTNAME}" ]]; then
   update_repo || echo "Ignored errors when updating OS repo index"
   # DATAPROC_IMAGE_VERSION is the preferred variable, but it doesn't exist in
   # old images.


### PR DESCRIPTION
Recent change in the hostname implementation has required that we find short hostname using a different mechanism.  This patch makes that change.