### PR TITLE
Issue #1175: [rstudio] use keyserver.ubuntu.com

### DIFF
--- a/rstudio/rstudio.sh
+++ b/rstudio/rstudio.sh
@@ -122,7 +122,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
 
   # Install RStudio Server
   REPOSITORY_KEY=95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7
-  run_with_retries apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys ${REPOSITORY_KEY}
+  run_with_retries apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${REPOSITORY_KEY}
   # https://cran.r-project.org/bin/linux/ubuntu/
   if [[ "${OS_ID}" == "ubuntu" ]]; then
     curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/67251078/gpg-keyserver-send-failed-no-keyserver-available-when-sending-to-hkp-pool 