### PR TITLE
[RStudio] fixing the test failure for 2.0 ubuntu images.

### DIFF
--- a/integration_tests/dataproc_test_case.py
+++ b/integration_tests/dataproc_test_case.py
@@ -47,6 +47,7 @@ class DataprocTestCase(parameterized.TestCase):
     COMPONENT = None
     INIT_ACTIONS = None
     INIT_ACTIONS_REPO = None
+    IMAGE_VERSION_2_2 = ['2.2-debian12', '2.2-ubuntu22', '2.2-rocky9']
 
     @classmethod
     def setUpClass(cls):
@@ -114,6 +115,8 @@ class DataprocTestCase(parameterized.TestCase):
             args.append("--image={}".format(FLAGS.image))
         elif FLAGS.image_version:
             args.append("--image-version={}".format(FLAGS.image_version))
+            if FLAGS.image_version in self.IMAGE_VERSION_2_2:
+                args.append("--public-ip-address")
 
         if optional_components:
             args.append("--optional-components={}".format(

--- a/rstudio/rstudio.sh
+++ b/rstudio/rstudio.sh
@@ -103,6 +103,17 @@ function run_with_retries() {
   "${cmd[@]}"
 }
 
+function install_package() {
+  local LIBDEFLATE0_URL="http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdeflate/libdeflate0_1.5-3_amd64.deb"
+  local LIBDEFLATE_DEV_URL="http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdeflate/libdeflate-dev_1.5-3_amd64.deb"
+  TMP_DIR=$(mktemp -d)
+  wget -q -P "${TMP_DIR}" "${LIBDEFLATE0_URL}"
+  dpkg -i "${TMP_DIR}/$(basename "${LIBDEFLATE0_URL}")"
+  wget -q -P "${TMP_DIR}" "${LIBDEFLATE_DEV_URL}"
+  dpkg -i "${TMP_DIR}/$(basename "${LIBDEFLATE_DEV_URL}")"
+  rm -rf "${TMP_DIR}"
+}
+
 if [[ "${ROLE}" == 'Master' ]]; then
   if [[ ${OS_ID} == debian ]] && [[ $(echo "${DATAPROC_IMAGE_VERSION} <= 2.1" | bc -l) == 1 ]]; then
     remove_old_backports
@@ -129,6 +140,9 @@ if [[ "${ROLE}" == 'Master' ]]; then
   fi
   apt-get install -y software-properties-common
   add-apt-repository "deb http://cran.r-project.org/bin/linux/${OS_ID} ${OS_CODE}-cran40/"
+  if [[ ${OS_ID} == ubuntu ]] && [[ $(echo "${DATAPROC_IMAGE_VERSION} == 2.0" | bc -l) == 1 ]]; then
+    install_package
+  fi
   update_apt_get
   apt-get install -y r-base r-base-dev gdebi-core
 
@@ -147,7 +161,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
   fi
   if [[ -z "${USER_PASSWORD}" ]]; then
     service_file=/etc/systemd/system/rstudio-server.service
-    if [[ "${OS_CODE}" == "bookworm" ]];then
+    if [[ "${OS_CODE}" == "bookworm" ]] || [[ "${OS_CODE}" == "jammy" ]];then
       service_file=/lib/systemd/system/rstudio-server.service
     fi
     sed -i 's:ExecStart=\(.*\):Environment=USER=rstudio\nExecStart=\1 --auth-none 1:1' "$service_file"


### PR DESCRIPTION
**libdeflate-dev** and **libdeflate0** are removed from the ubuntu library being used as source. 

- Make a temporary directory
- Download the archived version for both mentioned packages in the temp directory
- Using **dpkg** install both the packages and call the function only when the **OS** is **ubuntu** and the **image version** is **2.0**