### PR TITLE
[bigtable] using modern url for shc-core and shc-examples jar packages

### DIFF
--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -42,7 +42,7 @@ readonly BIGTABLE_HBASE_CLIENT_2X_VERSION='2.12.0'
 readonly BIGTABLE_HBASE_CLIENT_2X_JAR="bigtable-hbase-2.x-hadoop-${BIGTABLE_HBASE_CLIENT_2X_VERSION}.jar"
 readonly BIGTABLE_HBASE_CLIENT_2X_URL="${BIGTABLE_HBASE_CLIENT_2X_REPO}/${BIGTABLE_HBASE_CLIENT_2X_VERSION}/${BIGTABLE_HBASE_CLIENT_2X_JAR}"
 
-readonly SCH_REPO="https://repo.hortonworks.com/content/groups/public/com/hortonworks"
+readonly SCH_REPO="https://repo.hortonworks.com/content/repositories/releases/com/hortonworks"
 readonly SHC_VERSION='1.1.1-2.1-s_2.11'
 readonly SHC_JAR="shc-core-${SHC_VERSION}.jar"
 readonly SHC_EXAMPLES_JAR="shc-examples-${SHC_VERSION}.jar"

--- a/bigtable/test_bigtable.py
+++ b/bigtable/test_bigtable.py
@@ -70,7 +70,7 @@ class BigTableTestCase(DataprocTestCase):
     )
     def test_bigtable(self, configuration, machine_suffixes):
         self.createCluster(
-            configuration, self.INIT_ACTIONS, metadata=self.metadata)
+            configuration, self.INIT_ACTIONS, metadata=self.metadata, timeout_in_minutes=15)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),


### PR DESCRIPTION
Thanks to @dilipgodhia for the patch

tests done were manually, and only exercised the variable changed:

```
SCH_REPO="https://repo.hortonworks.com/content/repositories/releases/com/hortonworks"
SHC_VERSION='1.1.1-2.1-s_2.11'
SHC_JAR="shc-core-${SHC_VERSION}.jar"
SHC_EXAMPLES_JAR="shc-examples-${SHC_VERSION}.jar"
SHC_URL="${SCH_REPO}/shc-core/${SHC_VERSION}/${SHC_JAR}"
SHC_EXAMPLES_URL="${SCH_REPO}/shc-examples/${SHC_VERSION}/${SHC_EXAMPLES_JAR}"
cjac@cjac:~/src/github/cjac/initialization-actions$ wget "${SHC_EXAMPLES_URL}" ; echo $?
--2024-07-08 09:54:06--  https://repo.hortonworks.com/content/repositories/releases/com/hortonworks/shc-examples/1.1.1-2.1-s_2.11/shc-examples-1.1.1-2.1-s_2.11.jar
Resolving repo.hortonworks.com (repo.hortonworks.com)... 54.149.82.252, 35.164.245.218, 44.233.237.20
Connecting to repo.hortonworks.com (repo.hortonworks.com)|54.149.82.252|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 128482 (125K) [application/java-archive]
Saving to: ‘shc-examples-1.1.1-2.1-s_2.11.jar.2’

shc-examples-1.1.1-2.1-s_ 100%[===================================>] 125.47K  --.-KB/s    in 0.03s   

2024-07-08 09:54:06 (4.20 MB/s) - ‘shc-examples-1.1.1-2.1-s_2.11.jar.2’ saved [128482/128482]

0
```
