### PR TITLE
[rapids] bringing action up to date

### DIFF
--- a/rapids/rapids.sh
+++ b/rapids/rapids.sh
@@ -2,22 +2,69 @@
 
 set -euxo pipefail
 
+# Detect dataproc image version from its various names
+if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
+  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
+fi
+
+function os_id() {
+  grep '^ID=' /etc/os-release | cut -d= -f2 | xargs
+}
+
+function os_version() {
+  grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | xargs
+}
+
+function os_codename() {
+  grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs
+}
+
+function is_rocky() {
+  [[ "$(os_id)" == 'rocky' ]]
+}
+
+function is_ubuntu() {
+  [[ "$(os_id)" == 'ubuntu' ]]
+}
+
+function is_debian() {
+  [[ "$(os_id)" == 'debian' ]]
+}
+
+function is_debian11() {
+  is_debian && [[ "$(os_version)" == '11'* ]]
+}
+
+function is_debian12() {
+  is_debian && [[ "$(os_version)" == '12'* ]]
+}
+
+function os_vercat() {
+  if is_ubuntu ; then
+      os_version | sed -e 's/[^0-9]//g'
+  elif is_rocky ; then
+      os_version | sed -e 's/[^0-9].*$//g'
+  else
+      os_version
+  fi
+}
+
 function get_metadata_attribute() {
   local -r attribute_name=$1
   local -r default_value=$2
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-readonly DEFAULT_DASK_RAPIDS_VERSION="22.10"
+readonly DEFAULT_DASK_RAPIDS_VERSION="23.12"
 readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_DASK_RAPIDS_VERSION})
 
 readonly SPARK_VERSION_ENV=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
 readonly DEFAULT_SPARK_RAPIDS_VERSION="22.10.0"
 
 if [[ "${SPARK_VERSION_ENV%%.*}" == "3" ]]; then
-  readonly DEFAULT_CUDA_VERSION="11.5"
-  readonly DEFAULT_CUDF_VERSION="22.10.0"
-  readonly DEFAULT_XGBOOST_VERSION="1.6.2"
+  readonly DEFAULT_CUDA_VERSION="11.8"
+  readonly DEFAULT_CUDF_VERSION="23.12.1"
+  readonly DEFAULT_XGBOOST_VERSION="2.0.3"
   readonly DEFAULT_XGBOOST_GPU_SUB_VERSION="0.3.0"
   readonly SPARK_VERSION="${SPARK_VERSION_ENV}"
 else
@@ -43,6 +90,9 @@ readonly SPARK_RAPIDS_VERSION=$(get_metadata_attribute 'spark-rapids-version' ${
 readonly XGBOOST_VERSION=$(get_metadata_attribute 'xgboost-version' ${DEFAULT_XGBOOST_VERSION})
 readonly XGBOOST_GPU_SUB_VERSION=$(get_metadata_attribute 'spark-gpu-sub-version' ${DEFAULT_XGBOOST_GPU_SUB_VERSION})
 
+# Scala config
+readonly SCALA_VER="2.12"
+
 # Dask config
 readonly DASK_LAUNCHER=/usr/local/bin/dask-launcher.sh
 readonly DASK_SERVICE=dask-cluster
@@ -63,16 +113,25 @@ function execute_with_retries() {
 }
 
 function install_dask_rapids() {
+  if is_debian10; then
+      local python_ver="3.9"
+  elif is_debian11; then
+      local python_ver="3.10"
+  elif is_debian12; then
+      local python_ver="3.11"
+  else
+      local python_ver="3.9"
+  fi
   # Install RAPIDS, cudatoolkit
   mamba install -m -n 'dask-rapids' -y --no-channel-priority -c 'conda-forge' -c 'nvidia' -c 'rapidsai' \
-    "cudatoolkit=${CUDA_VERSION}" "pandas<1.5" "rapids=${RAPIDS_VERSION}" "python=3.9"
+    "cudatoolkit=${CUDA_VERSION}" "pandas<1.5" "rapids=${RAPIDS_VERSION}" "python=${python_ver}"
 }
 
 function install_spark_rapids() {
   local -r rapids_repo_url='https://repo1.maven.org/maven2/ai/rapids'
   local -r nvidia_repo_url='https://repo1.maven.org/maven2/com/nvidia'
   local -r dmlc_repo_url='https://repo.maven.apache.org/maven2/ml/dmlc'
-  
+
   # Convert . to - for URL formatting
   local cudf_cuda_version="${CUDA_VERSION//\./-}"
 
@@ -84,13 +143,13 @@ function install_spark_rapids() {
 
   if [[ "${SPARK_VERSION}" == "3"* ]]; then
     wget -nv --timeout=30 --tries=5 --retry-connrefused \
-      "${dmlc_repo_url}/xgboost4j-spark-gpu_2.12/${XGBOOST_VERSION}/xgboost4j-spark-gpu_2.12-${XGBOOST_VERSION}.jar" \
+      "${dmlc_repo_url}/xgboost4j-spark-gpu_${SCALA_VER}/${XGBOOST_VERSION}/xgboost4j-spark-gpu_${SCALA_VER}-${XGBOOST_VERSION}.jar" \
       -P /usr/lib/spark/jars/
     wget -nv --timeout=30 --tries=5 --retry-connrefused \
-      "${dmlc_repo_url}/xgboost4j-gpu_2.12/${XGBOOST_VERSION}/xgboost4j-gpu_2.12-${XGBOOST_VERSION}.jar" \
+      "${dmlc_repo_url}/xgboost4j-gpu_${SCALA_VER}/${XGBOOST_VERSION}/xgboost4j-gpu_${SCALA_VER}-${XGBOOST_VERSION}.jar" \
       -P /usr/lib/spark/jars/
     wget -nv --timeout=30 --tries=5 --retry-connrefused \
-      "${nvidia_repo_url}/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar" \
+      "${nvidia_repo_url}/rapids-4-spark_${SCALA_VER}/${SPARK_RAPIDS_VERSION}/rapids-4-spark_${SCALA_VER}-${SPARK_RAPIDS_VERSION}.jar" \
       -P /usr/lib/spark/jars/
   else
     wget -nv --timeout=30 --tries=5 --retry-connrefused \
@@ -107,7 +166,7 @@ function configure_spark() {
     cat >>${SPARK_CONF_DIR}/spark-defaults.conf <<EOF
 
 ###### BEGIN : RAPIDS properties for Spark ${SPARK_VERSION} ######
-# Rapids Accelerator for Spark can utilize AQE, but when the plan is not finalized, 
+# Rapids Accelerator for Spark can utilize AQE, but when the plan is not finalized,
 # query explain output won't show GPU operator, if user have doubt
 # they can uncomment the line before seeing the GPU plan explain, but AQE on gives user the best performance.
 # spark.sql.adaptive.enabled=false

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -58,8 +58,6 @@ class RapidsTestCase(DataprocTestCase):
                             ("STANDARD", ["m"], GPU_T4, "standalone"))
   def test_rapids_dask(self, configuration, machine_suffixes, accelerator,
                        dask_runtime):
-    # if self.getImageOs() == 'rocky':
-    #   self.skipTest("Not supported in Rocky Linux-based images")
 
     if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")
@@ -85,8 +83,6 @@ class RapidsTestCase(DataprocTestCase):
   @parameterized.parameters(("SINGLE", ["m"], GPU_T4),
                             ("STANDARD", ["w-0"], GPU_T4))
   def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
-    # if self.getImageOs() == 'rocky':
-    #   self.skipTest("Not supported in Rocky Linux-based images")
 
     if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")
@@ -114,9 +110,6 @@ class RapidsTestCase(DataprocTestCase):
   @parameterized.parameters(("STANDARD", ["w-0"], GPU_T4, "12.4"))
   def test_non_default_cuda_versions(self, configuration, machine_suffixes,
                                      accelerator, cuda_version):
-
-#    if self.getImageOs() == 'rocky':
-#      self.skipTest("Not supported in Rocky Linux-based images")
 
     if self.getImageVersion() < pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -58,8 +58,8 @@ class RapidsTestCase(DataprocTestCase):
                             ("STANDARD", ["m"], GPU_T4, "standalone"))
   def test_rapids_dask(self, configuration, machine_suffixes, accelerator,
                        dask_runtime):
-    if self.getImageOs() == 'rocky':
-      self.skipTest("Not supported in Rocky Linux-based images")
+    # if self.getImageOs() == 'rocky':
+    #   self.skipTest("Not supported in Rocky Linux-based images")
 
     if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")
@@ -85,12 +85,14 @@ class RapidsTestCase(DataprocTestCase):
   @parameterized.parameters(("SINGLE", ["m"], GPU_T4),
                             ("STANDARD", ["w-0"], GPU_T4))
   def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
-    if self.getImageOs() == 'rocky':
-      self.skipTest("Not supported in Rocky Linux-based images")
+    # if self.getImageOs() == 'rocky':
+    #   self.skipTest("Not supported in Rocky Linux-based images")
 
     if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")
     optional_components = None
+
+    metadata = ("gpu-driver-provider=NVIDIA,rapids-runtime=SPARK")
 
     self.createCluster(
         configuration,

--- a/rapids/test_rapids.py
+++ b/rapids/test_rapids.py
@@ -15,6 +15,7 @@ class RapidsTestCase(DataprocTestCase):
   ]
 
   GPU_P100 = "type=nvidia-tesla-p100"
+  GPU_T4 = "type=nvidia-tesla-t4"
 
   # Tests for RAPIDS init action
   DASK_RAPIDS_TEST_SCRIPT_FILE_NAME = "verify_rapids_dask.py"
@@ -52,9 +53,9 @@ class RapidsTestCase(DataprocTestCase):
     self.remove_test_script(self.XGBOOST_SPARK_TEST_SCRIPT_FILE_NAME,
                             instance_name)
 
-  @parameterized.parameters(("STANDARD", ["m", "w-0"], GPU_P100, None),
-                            ("STANDARD", ["m", "w-0"], GPU_P100, "yarn"),
-                            ("STANDARD", ["m"], GPU_P100, "standalone"))
+  @parameterized.parameters(("STANDARD", ["m", "w-0"], GPU_T4, None),
+                            ("STANDARD", ["m", "w-0"], GPU_T4, "yarn"),
+                            ("STANDARD", ["m"], GPU_T4, "standalone"))
   def test_rapids_dask(self, configuration, machine_suffixes, accelerator,
                        dask_runtime):
     if self.getImageOs() == 'rocky':
@@ -81,8 +82,8 @@ class RapidsTestCase(DataprocTestCase):
       self.verify_dask_instance("{}-{}".format(self.getClusterName(),
                                                machine_suffix))
 
-  @parameterized.parameters(("SINGLE", ["m"], GPU_P100),
-                            ("STANDARD", ["w-0"], GPU_P100))
+  @parameterized.parameters(("SINGLE", ["m"], GPU_T4),
+                            ("STANDARD", ["w-0"], GPU_T4))
   def test_rapids_spark(self, configuration, machine_suffixes, accelerator):
     if self.getImageOs() == 'rocky':
       self.skipTest("Not supported in Rocky Linux-based images")
@@ -108,12 +109,12 @@ class RapidsTestCase(DataprocTestCase):
     # Only need to do this once
     self.verify_spark_job()
 
-  @parameterized.parameters(("STANDARD", ["w-0"], GPU_P100, "11.2"))
+  @parameterized.parameters(("STANDARD", ["w-0"], GPU_T4, "12.4"))
   def test_non_default_cuda_versions(self, configuration, machine_suffixes,
                                      accelerator, cuda_version):
 
-    if self.getImageOs() == 'rocky':
-      self.skipTest("Not supported in Rocky Linux-based images")
+#    if self.getImageOs() == 'rocky':
+#      self.skipTest("Not supported in Rocky Linux-based images")
 
     if self.getImageVersion() < pkg_resources.parse_version("2.0"):
       self.skipTest("Not supported in pre 2.0 images")


### PR DESCRIPTION
* adding functions to check running environment OS
* set rapids version to 23.12
* set cuda version to 11.8
* remove cudf variables - they are unused
* set xgboost version to 2.0.3
* created variable to store scala version for future move from 2.12 to 2.13
* setting python_ver by operating system