### PR TITLE
Update kafka.sh

### DIFF
--- a/kafka/kafka.sh
+++ b/kafka/kafka.sh
@@ -150,7 +150,7 @@ function install_and_configure_kafka_server() {
     fi
   else
     # For worker nodes, broker ID is the worker ID.
-    BROKER_ID=$(hostname | sed 's/.*-w-\([0-9]*\)$/\1/g')
+    BROKER_ID=$((RANDOM % 10000))
   fi
   sed -i 's|log.dirs=/tmp/kafka-logs|log.dirs=/var/lib/kafka-logs|' \
     "${KAFKA_PROP_FILE}"

--- a/kafka/kafka.sh
+++ b/kafka/kafka.sh
@@ -149,7 +149,8 @@ function install_and_configure_kafka_server() {
       BROKER_ID=$((10000 + $(hostname | sed 's/.*-m-\([0-9]*\)$/\1/g')))
     fi
   else
-    # For worker nodes, broker ID is the worker ID.
+    # For worker nodes, broker ID is a random number generated less than 10000.
+    # 10000 is choosen since the max broker ID allowed being set is 10000.
     BROKER_ID=$((RANDOM % 10000))
   fi
   sed -i 's|log.dirs=/tmp/kafka-logs|log.dirs=/var/lib/kafka-logs|' \


### PR DESCRIPTION
With primary workers naming convention getting changed, we cannot rely on the worker number anymore, hence changing the broker id for primary workers.