### PR TITLE
[spark-rapids] Prevent automatic updates for Nvidia packages

### DIFF
--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -345,7 +345,7 @@ readonly NVIDIA_REPO_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64"
 function hold_nvidia_packages() {
   apt-mark hold nvidia-*
   apt-mark hold libnvidia-*
-  apt-mark hold xserver-xorg-video-nvidia-*
+  apt-mark hold xserver-xorg-video-nvidia*
 }
 
 # Install NVIDIA GPU driver provided by NVIDIA

--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -345,7 +345,9 @@ readonly NVIDIA_REPO_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64"
 function hold_nvidia_packages() {
   apt-mark hold nvidia-*
   apt-mark hold libnvidia-*
-  apt-mark hold xserver-xorg-video-nvidia*
+  if apt list --installed 2>/dev/null | grep -q "xserver-xorg-video-nvidia"; then
+    sudo apt-mark hold xserver-xorg-video-nvidia*
+  fi
 }
 
 # Install NVIDIA GPU driver provided by NVIDIA

--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -340,6 +340,14 @@ EOF
 readonly NVIDIA_BASE_DL_URL='https://developer.download.nvidia.com/compute'
 readonly NVIDIA_REPO_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64"
 
+# Hold all NVIDIA-related packages from upgrading unintenionally or services like unattended-upgrades
+# Users should run apt-mark unhold before they wish to upgrade these packages
+function hold_nvidia_packages() {
+  apt-mark hold nvidia-*
+  apt-mark hold libnvidia-*
+  apt-mark hold xserver-xorg-video-nvidia-*
+}
+
 # Install NVIDIA GPU driver provided by NVIDIA
 function install_nvidia_gpu_driver() {
 
@@ -387,6 +395,8 @@ function install_nvidia_gpu_driver() {
 
     # enable a systemd service that updates kernel headers after reboot
     setup_systemd_update_headers
+    # prevent auto upgrading nvidia packages
+    hold_nvidia_packages
 
   elif is_ubuntu ; then
 
@@ -471,6 +481,8 @@ function install_nvidia_gpu_driver() {
 
     # enable a systemd service that updates kernel headers after reboot
     setup_systemd_update_headers
+    # prevent auto upgrading nvidia packages
+    hold_nvidia_packages
 
   elif is_rocky ; then
 

--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -345,8 +345,8 @@ readonly NVIDIA_REPO_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64"
 function hold_nvidia_packages() {
   apt-mark hold nvidia-*
   apt-mark hold libnvidia-*
-  if apt list --installed 2>/dev/null | grep -q "xserver-xorg-video-nvidia"; then
-    sudo apt-mark hold xserver-xorg-video-nvidia*
+  if dpkg -l | grep -q "xserver-xorg-video-nvidia"; then
+    apt-mark hold xserver-xorg-video-nvidia*
   fi
 }
 


### PR DESCRIPTION
This PR uses `apt-mark hold` to prevent auto upgrades for Nvidia packages.


signed-off-by: Suraj Aralihalli <suraj.ara16@gmail.com>