### PR TITLE
[dask] Updated to work with modern environments

### DIFF
--- a/dask/test_dask.py
+++ b/dask/test_dask.py
@@ -16,11 +16,19 @@ class DaskTestCase(DataprocTestCase):
     def verify_dask_yarn(self, name):
         self._run_dask_test_script(name, self.DASK_YARN_TEST_SCRIPT)
 
-    def verify_dask_standalone(self, name):
-        self._run_dask_test_script(name, self.DASK_STANDALONE_TEST_SCRIPT)
+    def verify_dask_standalone(self, name, master_hostname):
+        script=self.DASK_STANDALONE_TEST_SCRIPT
+        verify_cmd = "/opt/conda/miniconda3/envs/dask/bin/python {} {}".format(
+            script,
+            master_hostname
+        )
+        abspath=os.path.join(os.path.dirname(os.path.abspath(__file__)),script)
+        self.upload_test_file(abspath, name)
+        self.assert_instance_command(name, verify_cmd)
+        self.remove_test_script(script, name)
 
     def _run_dask_test_script(self, name, script):
-        verify_cmd = "/opt/conda/default/bin/python {}".format(
+        verify_cmd = "/opt/conda/miniconda3/envs/dask/bin/python {}".format(
             script)
         self.upload_test_file(
             os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -30,12 +38,9 @@ class DaskTestCase(DataprocTestCase):
 
 
     @parameterized.parameters(
-        ("STANDARD", ["m", "w-0"], None),
         ("STANDARD", ["m", "w-0"], "yarn"),
         ("STANDARD", ["m"], "standalone"))
     def test_dask(self, configuration, instances, runtime):
-        if self.getImageOs() == 'rocky':
-            self.skipTest("Not supported in Rocky Linux-based images")
 
         if self.getImageVersion() < pkg_resources.parse_version("2.0"):
             self.skipTest("Not supported in pre-2.0 images")
@@ -46,15 +51,20 @@ class DaskTestCase(DataprocTestCase):
 
         self.createCluster(configuration,
                            self.INIT_ACTIONS,
-                           machine_type='e2-standard-2',
+                           machine_type='n1-standard-16',
                            metadata=metadata,
                            timeout_in_minutes=20)
-        
+
+        if configuration == 'HA':
+            master_hostname = self.getClusterName() + '-m-0'
+        else:
+            master_hostname = self.getClusterName() + '-m'
+
         for instance in instances:
             name = "{}-{}".format(self.getClusterName(), instance)
 
-            if runtime is "standalone":
-                self.verify_dask_standalone(name)
+            if runtime == "standalone":
+                self.verify_dask_standalone(name, master_hostname)
             else:
                 self.verify_dask_yarn(name)
 

--- a/dask/verify_dask_standalone.py
+++ b/dask/verify_dask_standalone.py
@@ -1,11 +1,44 @@
 from dask.distributed import Client
 import dask.array as da
+import sys
 import dask_ml
 import dask_bigquery
 
 import numpy as np
 
-client = Client("localhost:8786")
+print("imports processed")
+
+master_hostname="localhost"
+if len(sys.argv) > 1:
+  master_hostname=sys.argv[1]
+
+print("Master node hostname: " + master_hostname)
+print("timeout here means scheduler service may not be running")
+client = Client(master_hostname+":8786")
+
+print("Client instantiated")
 
 x = da.sum(np.ones(5))
+
+print("Simple dask array defined")
+print("timeout here means worker service may not be running")
 x.compute()
+
+print("Simple dask array computed")
+
+# https://examples.dask.org/array.html
+x = da.random.random((10000, 10000), chunks=(1000, 1000))
+
+print("Multi-dimension dask array defined")
+x.compute()
+
+print("Multi-dimension dask array computed")
+
+y = x + x.T
+z = y[::2, 5000:].mean(axis=1)
+
+print("mean analysis defined")
+
+z.compute()
+
+print("mean analysis computed")

--- a/dask/verify_dask_yarn.py
+++ b/dask/verify_dask_yarn.py
@@ -3,11 +3,53 @@ from dask.distributed import Client
 import dask.array as da
 import dask_ml
 import dask_bigquery
+import skein
 
 import numpy as np
 
-cluster = YarnCluster()
+print("imports successful")
+
+print("configuring skein client")
+skein.Client.stop_global_driver(force=True)
+skein.Client.start_global_driver(log_level='debug', log='/tmp/verify_dask_yarn-driver.log')
+
+print("skein version follows")
+print(skein.__version__)
+
+print("creating an application specification")
+spec = skein.ApplicationSpec.from_yaml("""
+name: verify-skein
+queue: default
+
+master:
+  script: echo "Things worked!"
+""")
+
+print("Instantiating skein.Client object")
+skeinClient = skein.Client.from_global_driver()
+
+skeinClient.get_applications()
+skeinClient.submit(spec)
+
+print("Instantiating dask-yarn.YarnCluster object")
+import time
+for i in range(10):
+    try:
+       time.sleep(0.3)
+       skeinClient = skein.Client.from_global_driver()
+       cluster = YarnCluster(skein_client=skeinClient)
+       break
+    except Exception as err:
+        print("retrying failed YarnCluster instantiation")
+        time.sleep(5)
+
+print("Instantiating dask.distributed.Client object")
 client = Client(cluster)
 
+print("Client object instantiated")
 x = da.sum(np.ones(5))
+
+print("created problem using dask.array.sum")
 x.compute()
+
+print("sum problem solved")


### PR DESCRIPTION
Updated to work with modern packages

dask.sh:
* removed most os condition tests ; this action is generally OS agnostic
* using the specific conda environment rather than the "default"
* declaring variables where they are used
* broke systemd units into scheduler and worker
* * only starting scheduler on primary master
* * only starting worker on master if dask-worker-on-master is not set to false
* updated knox xml to reference master node instead of localhost
* since dask-yarn only works with older libs, we are much more specific about the mamba/conda install packages

test_dask.py:
* removed rocky test inhibitions
* changed test machine type from e2-standard-2 to n1-standard-16
* self.verify_dask_standalone now takes an argument pointing to the master node
* using correct conda environment

verify_dask_standalone.py: 
* Scheduler now only runs on primary master node
* tests now specify the node of the scheduler
* Helpful debug messages now printed during test

verify_dask_yarn.py:
* YarnCluster object instantiated using skein.Client to reduce complexity
* YarnCluster object instantiation now wrapped in an exception handler with retry due to its flakiness
* Helpful debug messages now printed during test