### PR TITLE
[gpu] non-spark rapids runtime should also use CUDA 12.4

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -112,4 +112,4 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['container', 'images', 'delete', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID']
 
-timeout: 7200s
+timeout: 14400s

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -28,6 +28,7 @@ configure_gcloud_ssh_key() {
 # so we can diff what changed relatively to master branch.
 initialize_git_repo() {
   rm -fr .git
+  git config --global init.defaultBranch main
   git init
 
   git config user.email "ia-tests@presubmit.example.com"
@@ -36,7 +37,7 @@ initialize_git_repo() {
   git remote add origin "https://github.com/GoogleCloudDataproc/initialization-actions.git"
   git fetch origin master
   # Fetch all PRs to get history for PRs created from forked repos
-  git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*
+  git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/* > /dev/null 2>&1
 
   git reset --hard "${COMMIT_SHA}"
 
@@ -59,6 +60,7 @@ determine_tests_to_run() {
     return 0
   fi
 
+  set +x
   # Determines init actions directories that were changed
   declare -a changed_dirs
   for changed_file in "${CHANGED_FILES[@]}"; do
@@ -68,6 +70,7 @@ determine_tests_to_run() {
     changed_dir="${changed_dir%%/*}/"
     # Run all tests if common directories modified
     if [[ ${changed_dir} =~ ^(integration_tests|util|cloudbuild)/$ ]]; then
+      continue # remove this and merge all changes to integration_tests/ and cloudbuild/ into prince's branch before squash/merge
       echo "All tests will be run: '${changed_dir}' was changed"
       TESTS_TO_RUN=(":DataprocInitActionsTestSuite")
       return 0
@@ -93,6 +96,8 @@ determine_tests_to_run() {
     TESTS_TO_RUN+=("${test_target}")
   done
   echo "Tests: ${TESTS_TO_RUN[*]}"
+
+  set -x
 }
 
 run_tests() {

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -70,7 +70,6 @@ determine_tests_to_run() {
     changed_dir="${changed_dir%%/*}/"
     # Run all tests if common directories modified
     if [[ ${changed_dir} =~ ^(integration_tests|util|cloudbuild)/$ ]]; then
-      continue # remove this and merge all changes to integration_tests/ and cloudbuild/ into prince's branch before squash/merge
       echo "All tests will be run: '${changed_dir}' was changed"
       TESTS_TO_RUN=(":DataprocInitActionsTestSuite")
       return 0


### PR DESCRIPTION
* using CUDA 12.4 by default for all use cases
* fetch nvidia kernel code from tarball instead of git clone