### PR TITLE
[gpu] updates as result of rocky tests and running script with custom image generator

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1220,7 +1220,8 @@ function clean_up_sources_lists() {
 if is_debian ; then
   clean_up_sources_lists
   apt-get update
-  apt-mark unhold systemd libsystemd0
+  if is_debian12 ; then
+  apt-mark unhold systemd libsystemd0 ; fi
 fi
 
 configure_dkms_certs

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1079,17 +1079,13 @@ function clean_up_sources_lists() {
   #
   # bigtop (primary)
   #
-  local dataproc_repo_file="/etc/apt/sources.list.d/dataproc.list"
-  local -r bigtop_repo_url="https://storage.googleapis.com/goog-dataproc-bigtop-repo-us-west4/2_2_deb12_20240606_230238-RC01"
+  local -r dataproc_repo_file="/etc/apt/sources.list.d/dataproc.list"
   local -r bigtop_kr_path="/usr/share/keyrings/bigtop-keyring.gpg"
   rm -f "${bigtop_kr_path}"
   curl -fsS --retry-connrefused --retry 10 --retry-max-time 30 \
     "${bigtop_repo_url}/archive.key" | gpg --dearmor -o "${bigtop_kr_path}"
 
-  cat >"${dataproc_repo_file}" <<EOF
-deb [signed-by=${bigtop_kr_path}] ${bigtop_repo_url} dataproc contrib
-deb-src [signed-by=${bigtop_kr_path}] ${bigtop_repo_url} dataproc contrib
-EOF
+  sed -i -e 's:deb https:deb [signed-by=${bigtop_kr_path}] https:g' "${dataproc_repo_file}"
 
   #
   # adoptium
@@ -1118,12 +1114,17 @@ EOF
     > ${docker_repo_file}
 
   #
-  # google cloud
+  # google cloud + logging/monitoring
   #
-  if [[ -f /etc/apt/sources.list.d/google-cloud.list ]]; then
+  if ls /etc/apt/sources.list.d/google-cloud*.list ; then
     rm -f /usr/share/keyrings/cloud.google.gpg
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-    sed -i -e 's:deb https:deb [signed_by=/usr/share/keyrings/cloud.google.gpg] https:g' /etc/apt/sources.list.d/google-cloud.list
+    for list in google-cloud google-cloud-logging google-cloud-monitoring ; do
+      list_file="/etc/apt/sources.list.d/${list}.list"
+      if [[ -f "${list_file}" ]]; then
+        sed -i -e 's:deb https:deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https:g' "${list_file}"
+      fi
+    done
   fi
 
   #
@@ -1133,21 +1134,7 @@ EOF
     rm -f /usr/share/keyrings/cran-r.gpg
     curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x95c0faf38db3ccad0c080a7bdc78b2ddeabc47b7' | \
       gpg --dearmor -o /usr/share/keyrings/cran-r.gpg
-    sed -i -e 's:deb http:deb [signed_by=/usr/share/keyrings/cran-r.gpg] http:g' /etc/apt/sources.list.d/cran-r.list
-  fi
-
-  #
-  # google cloud + logging/monitoring
-  #
-  if ls /etc/apt/sources.list.d/google-cloud*.list ; then
-    rm -f /usr/share/keyrings/cloud.google.gpg
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-    for list in google-cloud google-cloud-logging google-cloud-monitoring ; do
-      list_file="/etc/apt/sources.list.d/${list}.list"
-      if [[ -f "${list_file}" ]]; then
-        sed -i -e 's:deb https:deb [signed_by=/usr/share/keyrings/cloud.google.gpg] https:g' "${list_file}"
-      fi
-    done
+    sed -i -e 's:deb http:deb [signed-by=/usr/share/keyrings/cran-r.gpg] http:g' /etc/apt/sources.list.d/cran-r.list
   fi
 
   #
@@ -1155,62 +1142,12 @@ EOF
   #
   if [[ -f /etc/apt/sources.list.d/mysql.list ]]; then
     rm -f /usr/share/keyrings/mysql.gpg
-    mysql_pgp_key_armored="-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: SKS 1.1.6
-Comment: Hostname: pgp.mit.edu
-
-mQINBGU2rNoBEACSi5t0nL6/Hj3d0PwsbdnbY+SqLUIZ3uWZQm6tsNhvTnahvPPZBGdl99iW
-YTt2KmXp0KeN2s9pmLKkGAbacQP1RqzMFnoHawSMf0qTUVjAvhnI4+qzMDjTNSBq9fa3nHmO
-YxownnrRkpiQUM/yD7/JmVENgwWb6akZeGYrXch9jd4XV3t8OD6TGzTedTki0TDNr6YZYhC7
-jUm9fK9Zs299pzOXSxRRNGd+3H9gbXizrBu4L/3lUrNf//rM7OvV9Ho7u9YYyAQ3L3+OABK9
-FKHNhrpi8Q0cbhvWkD4oCKJ+YZ54XrOG0YTg/YUAs5/3//FATI1sWdtLjJ5pSb0onV3LIbar
-RTN8lC4Le/5kd3lcot9J8b3EMXL5p9OGW7wBfmNVRSUI74Vmwt+v9gyp0Hd0keRCUn8lo/1V
-0YD9i92KsE+/IqoYTjnya/5kX41jB8vr1ebkHFuJ404+G6ETd0owwxq64jLIcsp/GBZHGU0R
-KKAo9DRLH7rpQ7PVlnw8TDNlOtWt5EJlBXFcPL+NgWbqkADAyA/XSNeWlqonvPlYfmasnAHA
-pMd9NhPQhC7hJTjCiAwG8UyWpV8Dj07DHFQ5xBbkTnKH2OrJtguPqSNYtTASbsWz09S8ujoT
-DXFT17NbFM2dMIiq0a4VQB3SzH13H2io9Cbg/TzJrJGmwgoXgwARAQABtDZNeVNRTCBSZWxl
-YXNlIEVuZ2luZWVyaW5nIDxteXNxbC1idWlsZEBvc3Mub3JhY2xlLmNvbT6JAlQEEwEIAD4W
-IQS8pDQXw7SF3RKOxtS3s7eIqNN4XAUCZTas2gIbAwUJA8JnAAULCQgHAgYVCgkICwIEFgID
-AQIeAQIXgAAKCRC3s7eIqNN4XLzoD/9PlpWtfHlI8eQTHwGsGIwFA+fgipyDElapHw3MO+K9
-VOEYRZCZSuBXHJe9kjGEVCGUDrfImvgTuNuqYmVUV+wyhP+w46W/cWVkqZKAW0hNp0TTvu3e
-Dwap7gdk80VF24Y2Wo0bbiGkpPiPmB59oybGKaJ756JlKXIL4hTtK3/hjIPFnb64Ewe4YLZy
-oJu0fQOyA8gXuBoalHhUQTbRpXI0XI3tpZiQemNbfBfJqXo6LP3/LgChAuOfHIQ8alvnhCwx
-hNUSYGIRqx+BEbJw1X99Az8XvGcZ36VOQAZztkW7mEfH9NDPz7MXwoEvduc61xwlMvEsUIaS
-fn6SGLFzWPClA98UMSJgF6sKb+JNoNbzKaZ8V5w13msLb/pq7hab72HH99XJbyKNliYj3+KA
-3q0YLf+Hgt4Y4EhIJ8x2+g690Np7zJF4KXNFbi1BGloLGm78akY1rQlzpndKSpZq5KWw8FY/
-1PEXORezg/BPD3Etp0AVKff4YdrDlOkNB7zoHRfFHAvEuuqti8aMBrbRnRSG0xunMUOEhbYS
-/wOOTl0g3bF9NpAkfU1Fun57N96Us2T9gKo9AiOY5DxMe+IrBg4zaydEOovgqNi2wbU0MOBQ
-b23Puhj7ZCIXcpILvcx9ygjkONr75w+XQrFDNeux4Znzay3ibXtAPqEykPMZHsZ2sbkCDQRl
-NqzaARAAsdvBo8WRqZ5WVVk6lReD8b6Zx83eJUkV254YX9zn5t8KDRjYOySwS75mJIaZLsv0
-YQjJk+5rt10tejyCrJIFo9CMvCmjUKtVbgmhfS5+fUDRrYCEZBBSa0Dvn68EBLiHugr+SPXF
-6o1hXEUqdMCpB6oVp6X45JVQroCKIH5vsCtw2jU8S2/IjjV0V+E/zitGCiZaoZ1f6NG7ozyF
-ep1CSAReZu/sssk0pCLlfCebRd9Rz3QjSrQhWYuJa+eJmiF4oahnpUGktxMD632I9aG+IMfj
-tNJNtX32MbO+Se+cCtVc3cxSa/pR+89a3cb9IBA5tFF2Qoekhqo/1mmLi93Xn6uDUhl5tVxT
-nB217dBT27tw+p0hjd9hXZRQbrIZUTyh3+8EMfmAjNSIeR+th86xRd9XFRr9EOqrydnALOUr
-9cT7TfXWGEkFvn6ljQX7f4RvjJOTbc4jJgVFyu8K+VU6u1NnFJgDiNGsWvnYxAf7gDDbUSXE
-uC2anhWvxPvpLGmsspngge4yl+3nv+UqZ9sm6LCebR/7UZ67tYz3p6xzAOVgYsYcxoIUuEZX
-jHQtsYfTZZhrjUWBJ09jrMvlKUHLnS437SLbgoXVYZmcqwAWpVNOLZf+fFm4IE5aGBG5Dho2
-CZ6ujngW9Zkn98T1d4N0MEwwXa2V6T1ijzcqD7GApZUAEQEAAYkCPAQYAQgAJhYhBLykNBfD
-tIXdEo7G1Lezt4io03hcBQJlNqzaAhsMBQkDwmcAAAoJELezt4io03hcXqMP/01aPT3A3Sg7
-oTQoHdCxj04ELkzrezNWGM+YwbSKrR2LoXR8zf2tBFzc2/Tl98V0+68f/eCvkvqCuOtq4392
-Ps23j9W3r5XG+GDOwDsx0gl0E+Qkw07pwdJctA6efsmnRkjF2YVO0N9MiJA1tc8NbNXpEEHJ
-Z7F8Ri5cpQrGUz/AY0eae2b7QefyP4rpUELpMZPjc8Px39Fe1DzRbT+5E19TZbrpbwlSYs1i
-CzS5YGFmpCRyZcLKXo3zS6N22+82cnRBSPPipiO6WaQawcVMlQO1SX0giB+3/DryfN9VuIYd
-1EWCGQa3O0MVu6o5KVHwPgl9R1P6xPZhurkDpAd0b1s4fFxin+MdxwmG7RslZA9CXRPpzo7/
-fCMW8sYOH15DP+YfUckoEreBt+zezBxbIX2CGGWEV9v3UBXadRtwxYQ6sN9bqW4jm1b41vNA
-17b6CVH6sVgtU3eN+5Y9an1e5jLD6kFYx+OIeqIIId/TEqwS61csY9aav4j4KLOZFCGNU0FV
-ji7NQewSpepTcJwfJDOzmtiDP4vol1ApJGLRwZZZ9PB6wsOgDOoP6sr0YrDI/NNX2RyXXbgl
-nQ1yJZVSH3/3eo6knG2qTthUKHCRDNKdy9Qqc1x4WWWtSRjh+zX8AvJK2q1rVLH2/3ilxe9w
-cAZUlaj3id3TxquAlud4lWDz
-=h5nH
------END PGP PUBLIC KEY BLOCK-----"
-#    curl 'https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html' | \
-#      perl -e '$c = join("",<STDIN>); $c =~ s/.+?(-----BEGIN PGP .* PUBLIC KEY BLOCK-----).+$/$1/ms; print $c, $/' | \
-    echo "${mysql_pgp_key_armored}" | gpg --dearmor -o /usr/share/keyrings/mysql.gpg
+    curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBCA43417C3B485DD128EC6D4B7B3B788A8D3785C' | \
+      gpg --dearmor -o /usr/share/keyrings/mysql.gpg
     sed -i -e 's:deb https:deb [signed-by=/usr/share/keyrings/mysql.gpg] https:g' /etc/apt/sources.list.d/mysql.list
   fi
 
-  mv /etc/apt/trusted.gpg /etc/apt/untrusted.gpg
+  mv /etc/apt/trusted.gpg /etc/apt/old-trusted.gpg
 
 }
 


### PR DESCRIPTION
Updates for Rocky, plus updates to allow the script to be run by the custom image generator

* reduce log noise a little
* Only unhold systemd on debian12
* encode get_metadata_value logic inline so this script works where `/usr/share/google/get_metadata_value` is not installed (custom-images)
* clean up argument passing to `execute_with_retries`
* allow access to DKMS keys for the duration of the install process instead of just during driver signing
* On Rocky, try to build drivers using DKMS with a fallback of installing pre-built binaries
* Do not install driver aliases on rocky
* remove extra `modprobe -r`
* in `configure_yarn`, skip update if `${HADOOP_CONF_DIR}` does not exist
* only `chown yarn:yarn` for directory list if directory list is not empty (including existing as a single element with element value 'None')
* corrected logic to modify the bigtop `sources.list` file rather than generating a new one
* using `$(os_codename)` rather than `${OS_CODENAME}`
* google cloud + logging/monitoring `sources.list` section tidy-up
* MySQL key is now fetched from `keyserver.ubuntu.com` rather than including inline
* making a backup of `/etc/apt/trusted.gpg` instead of removing without backup
* unholding `systemd` and `libsystemd0` on bookworm instead of force-upgrading