### PR TITLE
redirect backports repo on oldoldstable

### DIFF
--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -25,7 +25,7 @@ readonly KNOX_GW_CONFIG="$(sudo -u knox mktemp -d -t knox-init-action-config-XXX
 readonly KNOX_HOME=/usr/lib/knox
 
 # Detect dataproc image version from its various names
-if (! test -n DATAPROC_IMAGE_VERSION) && test -n DATAPROC_VERSION; then
+if [[ -n "${DATAPROC_IMAGE_VERSION}" && -n "${DATAPROC_VERSION}" ]]; then
   DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
   echo $DATAPROC_IMAGE_VERSION
 fi
@@ -159,7 +159,7 @@ function initialize_crontab() {
 function install() {
   local master_name
   master_name=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
-  if [[ "$DATAPROC_IMAGE_VERSION" == "2.2" ]]; then
+  if [[ "${DATAPROC_IMAGE_VERSION}" == "2.2" ]]; then
       if [[ "${master_name}" == $(hostname -A | tr -d '[:space:]' | awk -F "." '{print $1}') ]]; then
          [[ -z "${KNOX_GW_CONFIG_GCS}" ]] && err "Metadata knox-gw-config is not provided. knox-gw-config stores the configuration files for knox."
           
@@ -177,10 +177,10 @@ function install() {
       fi
   elif [[ "${master_name}" == $(hostname) ]]; then
     [[ -z "${KNOX_GW_CONFIG_GCS}" ]] && err "Metadata knox-gw-config is not provided. knox-gw-config stores the configuration files for knox."
-      if [ "$DATAPROC_IMAGE_VERSION" = "2.0" ]; then
+      if [ "${DATAPROC_IMAGE_VERSION}" = "2.0" ]; then
         echo "Dataproc version is 2.0"
         SUB_MINOR_VERSION=$(get_dataproc_sub_minor_version)
-        if [ "$SUB_MINOR_VERSION" -le 102 ]; then
+        if [ "${SUB_MINOR_VERSION}" -le 102 ]; then
            apply_changes
         fi
       fi

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -50,7 +50,8 @@ get_dataproc_sub_minor_version() {
 
 
 # Function to perform common operations in case of specific version_sub_minor version
-apply_changes() {
+comment_repo_line() {
+  # https://github.com/GoogleCloudDataproc/initialization-actions/issues/1157
   sed -i "s/^deb*/#deb/g" /etc/apt/sources.list.d/google-cloud-logging.list
   sed -i "s/https:\/\/deb.debian.org\/debian buster-backports main/https:\/\/archive.debian.org\/debian buster-backports main contrib non-free/g" /etc/apt/sources.list
 }
@@ -181,7 +182,7 @@ function install() {
         echo "Dataproc version is 2.0"
         SUB_MINOR_VERSION=$(get_dataproc_sub_minor_version)
         if [ "${SUB_MINOR_VERSION}" -le 102 ]; then
-           apply_changes
+           comment_repo_line
         fi
       fi
 

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -25,7 +25,7 @@ readonly KNOX_GW_CONFIG="$(sudo -u knox mktemp -d -t knox-init-action-config-XXX
 readonly KNOX_HOME=/usr/lib/knox
 
 # Detect dataproc image version from its various names
-if [[ -n "${DATAPROC_IMAGE_VERSION}" && -n "${DATAPROC_VERSION}" ]]; then
+if (! test -n "${DATAPROC_IMAGE_VERSION}") && test -n "${DATAPROC_VERSION}"; then
   DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
   echo $DATAPROC_IMAGE_VERSION
 fi


### PR DESCRIPTION
The knox.sh script has been updated to ensure compatibility across various Dataproc image versions. Here's a summary of the changes:

2.0.X-debian10:
Addressed an issue where the script failed for image versions less than or equal to 2.0.102-debian10 due to original keys had expired at https://keyserver.ubuntu.com.
Note: Cluster creation with these versions requires the cloud-platform scope.
2.1.X-debian11: The script functioned correctly with all 2.1.X-debian11 image versions.
2.2.x-debian12: Script was not working for 2.2 images . Resolved a problem caused by the hostname returning an FQDN in 2.2.x-debian12 images.

Testing:

Thorough testing was conducted with various cluster naming conventions (e.g., proxy-cluster, proxy-cluster-x, proxy-cluster-x-v) and across all supported image versions.