### PR TITLE
[gpu] performance and functionality improvements

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -1,0 +1,40 @@
+# This Dockerfile builds the container from which manual tests are run
+# This process needs to be executed manually from a git clone
+#
+# See manual-test-runner.sh for instructions
+
+FROM gcr.io/cloud-builders/gcloud
+
+RUN useradd -m -d /home/ia-tests -s /bin/bash ia-tests
+
+# Installed here are packages on which the tests depend
+RUN apt-get -qq update \
+  && apt-get -y -qq install \
+     apt-transport-https apt-utils \
+     ca-certificates libmime-base64-perl gnupg \
+     curl jq less screen > /dev/null 2>&1  && apt-get clean
+
+# Install bazel signing key, repo and package
+ENV bazel_kr_path=/usr/share/keyrings/bazel-release.pub.gpg
+ENV bazel_repo_data="http://storage.googleapis.com/bazel-apt stable jdk1.8"
+
+RUN /usr/bin/curl -s https://bazel.build/bazel-release.pub.gpg \
+      | gpg --dearmor -o "${bazel_kr_path}" \
+    && echo "deb [arch=amd64 signed-by=${bazel_kr_path}] ${bazel_repo_data}" \
+      | dd of=/etc/apt/sources.list.d/bazel.list status=none \
+    && apt-get update -qq
+
+RUN apt-get autoremove -y -qq && \
+    apt-get install -y -qq default-jdk python3-setuptools bazel > /dev/null 2>&1 && \
+    apt-get clean
+
+# Install here any utilities you find useful when troubleshooting
+RUN apt-get -y -qq install emacs-nox vim uuid-runtime > /dev/null 2>&1 && apt-get clean
+
+WORKDIR /init-actions
+
+USER ia-tests
+COPY --chown=ia-tests:ia-tests . ${WORKDIR}
+
+ENTRYPOINT ["/bin/bash"]
+#CMD ["/bin/bash"]

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -47,16 +47,15 @@ attached GPU adapters.
     CLUSTER_NAME=<cluster_name>
     gcloud dataproc clusters create ${CLUSTER_NAME} \
         --region ${REGION} \
-        --master-accelerator type=nvidia-tesla-v100 \
-        --worker-accelerator type=nvidia-tesla-v100,count=4 \
+        --master-accelerator type=nvidia-tesla-t4 \
+        --worker-accelerator type=nvidia-tesla-t4,count=4 \
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh
     ```
 
 1.  Use the `gcloud` command to create a new cluster with NVIDIA GPU drivers
     and CUDA installed by initialization action as well as the GPU
     monitoring service. The monitoring service is supported on Dataproc 2.0+ Debian
-    and Ubuntu images. Please create a Github issue if support is needed for other
-    Dataproc images.
+    and Ubuntu images.
 
     *Prerequisite:* Create GPU metrics in
     [Cloud Monitoring](https://cloud.google.com/monitoring/docs/) using Google
@@ -90,8 +89,8 @@ attached GPU adapters.
     CLUSTER_NAME=<cluster_name>
     gcloud dataproc clusters create ${CLUSTER_NAME} \
         --region ${REGION} \
-        --master-accelerator type=nvidia-tesla-v100 \
-        --worker-accelerator type=nvidia-tesla-v100,count=4 \
+        --master-accelerator type=nvidia-tesla-t4 \
+        --worker-accelerator type=nvidia-tesla-t4,count=4 \
         --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh \
         --metadata install-gpu-agent=true \
         --scopes https://www.googleapis.com/auth/monitoring.write
@@ -136,12 +135,12 @@ attached GPU adapters.
 #### GPU Scheduling in YARN:
 
 YARN is the default Resource Manager for Dataproc. To use GPU scheduling feature
-in Spark, it requires YARN version >= 2.10 or >=3.1.1. If intended to use Spark
+in Spark, it requires YARN version >= 2.10 or >= 3.1.1. If intended to use Spark
 with Deep Learning use case, it recommended to use YARN >= 3.1.3 to get support
-for [nvidia-docker version 2](https://github.com/NVIDIA/nvidia-docker).
+for [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit).
 
 In current Dataproc set up, we enable GPU resource isolation by initialization
-script without NVIDIA Docker, you can find more information at
+script with NVIDIA container toolkit.  You can find more information at
 [NVIDIA Spark RAPIDS getting started guide](https://nvidia.github.io/spark-rapids/).
 
 #### cuDNN

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -14,12 +14,14 @@ for CUDA, the nvidia kernel driver, cuDNN, and NCCL.
 Specifying a supported value for the `cuda-version` metadata variable
 will select the following values for Driver, CuDNN and NCCL.  At the
 time of writing, the default value for cuda-version, if unspecified is
-12.4.  In addition to 12.4, we have also tested with 11.8.
+12.4.  In addition to 12.4, we have also tested with 11.8, 12.0 and 12.6.
 
-CUDA | Full Version | Driver    | CuDNN     | NCCL    | Supported OSs
+CUDA | Full Version | Driver    | CuDNN     | NCCL    | Tested Dataproc Image Versions
 -----| ------------ | --------- | --------- | ------- | -------------------
-11.8 | 11.8.0       | 525.147   | 8.6.0.163 | 2.15.5  | All
-12.4 | 12.4.1       | 550.90.07 | 9.1.0.70  | 2.21.5  | ALL
+11.8 | 11.8.0       | 560.35.03 | 8.6.0.163 | 2.15.5  | 2.0, 2.1, 2.2-ubuntu22
+12.0 | 12.0.0       | 550.90.07 | 8.8.1.3,  | 2.16.5  | 2.0, 2.1, 2.2-rocky9, 2.2-ubuntu22
+12.4 | 12.4.1       | 550.90.07 | 9.1.0.70  | 2.23.4  | 2.1-ubuntu20, 2.1-rocky8, 2.2
+12.6 | 12.6.2       | 560.35.03 | 9.5.1.17  | 2.23.4  | 2.1-ubuntu20, 2.1-rocky8, 2.2
 
 All variants in the preceeding table have been manually tested to work
 with the installer.  Supported OSs at the time of writing are:
@@ -27,7 +29,6 @@ with the installer.  Supported OSs at the time of writing are:
 * Debian 10, 11 and 12
 * Ubuntu 18.04, 20.04, and 22.04 LTS
 * Rocky 8 and 9
-
 
 ## Using this initialization action
 

--- a/gpu/bazel.screenrc
+++ b/gpu/bazel.screenrc
@@ -1,0 +1,17 @@
+#
+# For debugging, uncomment the following line
+#
+
+# screen -L -t monitor 0 /bin/bash
+
+screen -L -t 2.0-debian10 1 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-debian10 ; exec /bin/bash'
+#screen -L -t 2.0-rocky8   2 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-rocky8   ; exec /bin/bash'
+#screen -L -t 2.0-ubuntu18 3 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-ubuntu18 ; exec /bin/bash'
+
+#screen -L -t 2.1-debian11 4 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.1-debian11 ; exec /bin/bash'
+#screen -L -t 2.1-rocky8   5 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.1-rocky8   ; exec /bin/bash'
+#screen -L -t 2.1-ubuntu20 6 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.1-ubuntu20 ; exec /bin/bash'
+
+#screen -L -t 2.2-debian12 7 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.2-debian12 ; exec /bin/bash'
+#screen -L -t 2.2-rocky9   8 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.2-rocky9   ; exec /bin/bash'
+#screen -L -t 2.2-ubuntu22 9 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.2-ubuntu22 ; exec /bin/bash'

--- a/gpu/bazel.screenrc
+++ b/gpu/bazel.screenrc
@@ -1,17 +1,11 @@
-#
-# For debugging, leave the following line uncommented.  For end to end testing, comment it instead.
-#
+screen -L -t 2.0-debian10 1 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.0-debian10 ; exec /bin/bash'
+#screen -L -t 2.0-rocky8   2 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.0-rocky8   ; exec /bin/bash'
+#screen -L -t 2.0-ubuntu18 3 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.0-ubuntu18 ; exec /bin/bash'
 
-screen -L -t monitor 0 /bin/bash
+#screen -L -t 2.1-debian11 4 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.1-debian11 ; exec /bin/bash'
+#screen -L -t 2.1-rocky8   5 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.1-rocky8   ; exec /bin/bash'
+#screen -L -t 2.1-ubuntu20 6 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.1-ubuntu20 ; exec /bin/bash'
 
-screen -L -t 2.0-debian10 1 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-debian10 ; exec /bin/bash'
-#screen -L -t 2.0-rocky8   2 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-rocky8   ; exec /bin/bash'
-#screen -L -t 2.0-ubuntu18 3 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-ubuntu18 ; exec /bin/bash'
-
-#screen -L -t 2.1-debian11 4 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.1-debian11 ; exec /bin/bash'
-#screen -L -t 2.1-rocky8   5 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.1-rocky8   ; exec /bin/bash'
-#screen -L -t 2.1-ubuntu20 6 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.1-ubuntu20 ; exec /bin/bash'
-
-#screen -L -t 2.2-debian12 7 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.2-debian12 ; exec /bin/bash'
-#screen -L -t 2.2-rocky9   8 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.2-rocky9   ; exec /bin/bash'
-#screen -L -t 2.2-ubuntu22 9 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.2-ubuntu22 ; exec /bin/bash'
+#screen -L -t 2.2-debian12 7 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.2-debian12 ; exec /bin/bash'
+#screen -L -t 2.2-rocky9   8 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.2-rocky9   ; exec /bin/bash'
+#screen -L -t 2.2-ubuntu22 9 sh -c '/bin/bash -x gpu/run-bazel-tests.sh 2.2-ubuntu22 ; exec /bin/bash'

--- a/gpu/bazel.screenrc
+++ b/gpu/bazel.screenrc
@@ -1,8 +1,8 @@
 #
-# For debugging, uncomment the following line
+# For debugging, leave the following line uncommented.  For end to end testing, comment it instead.
 #
 
-# screen -L -t monitor 0 /bin/bash
+screen -L -t monitor 0 /bin/bash
 
 screen -L -t 2.0-debian10 1 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-debian10 ; exec /bin/bash'
 #screen -L -t 2.0-rocky8   2 sh -c '/bin/bash -x rapids/run-bazel-tests.sh 2.0-rocky8   ; exec /bin/bash'

--- a/gpu/env.json.sample
+++ b/gpu/env.json.sample
@@ -1,0 +1,7 @@
+{
+  "PROJECT_ID":"example-yyyy-nn",
+  "PURPOSE":"cuda-pre-init",
+  "BUCKET":"my-bucket-name",
+  "IMAGE_VERSION":"2.2-debian12",
+  "ZONE":"us-west4-ñ"
+}

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -35,10 +35,15 @@ readonly -A supported_os=(
 for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
   eval "function is_${os_id_val}() ( set +x ;  [[ \"$(os_id)\" == '${os_id_val}' ]] ; )"
 
+  # os_vercat depends on is_ubuntu and is_rocky so re-implement here
+  if   [[ "${os_id_val}" == "ubuntu" ]] ; then vernum=$(os_version | sed -e 's/[^0-9]//g')
+  elif [[ "${os_id_val}" == "rocky" ]]  ; then vernum=$(os_version | sed -e 's/[^0-9].*$//g')
+  else vernum="$(os_version)" ; fi
+
   for osver in $(echo "${supported_os["${os_id_val}"]}") ; do
-    eval "function is_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && [[ \"$(os_version)\" == ${osver}* ]] ; )"
-    eval "function ge_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_ge \"$(os_version)\" ${osver} ; )"
-    eval "function le_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_le \"$(os_version)\" ${osver} ; )"
+    eval "function is_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && [[ \"${vernum}}\" == ${osver}* ]] ; )"
+    eval "function ge_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_ge \"${vernum}\" ${osver} ; )"
+    eval "function le_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_le \"${vernum}\" ${osver} ; )"
   done
 done
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -16,24 +16,26 @@
 
 set -euxo pipefail
 
-function os_id()       { grep '^ID=' /etc/os-release | cut -d= -f2 | xargs ; }
-function os_version()  { grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | xargs ; }
-function os_codename() { grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs ; }
-function is_rocky()    { [[ "$(os_id)" == 'rocky' ]] ; }
-function is_rocky8()   { is_rocky && [[ "$(os_version)" == '8'* ]] ; }
-function is_rocky9()   { is_rocky && [[ "$(os_version)" == '9'* ]] ; }
-function is_ubuntu()   { [[ "$(os_id)" == 'ubuntu' ]] ; }
-function is_ubuntu18() { is_ubuntu && [[ "$(os_version)" == '18.04'* ]] ; }
-function is_ubuntu20() { is_ubuntu && [[ "$(os_version)" == '20.04'* ]] ; }
-function is_ubuntu22() { is_ubuntu && [[ "$(os_version)" == '22.04'* ]] ; }
-function is_debian()   { [[ "$(os_id)" == 'debian' ]] ; }
-function is_debian10() { is_debian && [[ "$(os_version)" == '10'* ]] ; }
-function is_debian11() { is_debian && [[ "$(os_version)" == '11'* ]] ; }
-function is_debian12() { is_debian && [[ "$(os_version)" == '12'* ]] ; }
-function os_vercat()   { set +x
+function os_id()       ( set +x ;  grep '^ID=' /etc/os-release | cut -d= -f2 | xargs ; )
+function os_version()  ( set +x ;  grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | xargs ; )
+function os_codename() ( set +x ;  grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs ; )
+function is_rocky()    ( set +x ;  [[ "$(os_id)" == 'rocky' ]] ; )
+function is_rocky8()   ( set +x ;  is_rocky && [[ "$(os_version)" == '8'* ]] ; )
+function is_rocky9()   ( set +x ;  is_rocky && [[ "$(os_version)" == '9'* ]] ; )
+function is_ubuntu()   ( set +x ;  [[ "$(os_id)" == 'ubuntu' ]] ; )
+function is_ubuntu18() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '18.04'* ]] ; )
+function is_ubuntu20() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '20.04'* ]] ; )
+function is_ubuntu22() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '22.04'* ]] ; )
+function is_debian()   ( set +x ;  [[ "$(os_id)" == 'debian' ]] ; )
+function is_debian10() ( set +x ;  is_debian && [[ "$(os_version)" == '10'* ]] ; )
+function is_debian11() ( set +x ;  is_debian && [[ "$(os_version)" == '11'* ]] ; )
+function is_debian12() ( set +x ;  is_debian && [[ "$(os_version)" == '12'* ]] ; )
+function is_debuntu()  ( set +x ;  is_debian || is_ubuntu ; )
+
+function os_vercat()   ( set +x
   if   is_ubuntu ; then os_version | sed -e 's/[^0-9]//g'
   elif is_rocky  ; then os_version | sed -e 's/[^0-9].*$//g'
-                   else os_version ; fi ; set -x ; }
+                   else os_version ; fi ; )
 
 function remove_old_backports {
   if is_debian12 ; then return ; fi
@@ -56,11 +58,13 @@ function remove_old_backports {
   done
 }
 
+# Return true if the first argument is equal to or less than the second argument
 function compare_versions_lte { [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ] ; }
 
-function compare_versions_lt() {
+# Return true if the first argument is less than the second argument
+function compare_versions_lt() ( set +x
   [ "$1" = "$2" ] && return 1 || compare_versions_lte $1 $2
-}
+)
 
 function print_metadata_value() {
   local readonly tmpfile=$(mktemp)
@@ -83,7 +87,7 @@ function print_metadata_value_if_exists() {
   return ${return_code}
 }
 
-function get_metadata_value() {
+function get_metadata_value() (
   set +x
   local readonly varname=$1
   local -r MDS_PREFIX=http://metadata.google.internal/computeMetadata/v1
@@ -95,17 +99,16 @@ function get_metadata_value() {
     print_metadata_value_if_exists ${MDS_PREFIX}/project/${varname}
     return_code=$?
   fi
-  set -x
-  return ${return_code}
-}
 
-function get_metadata_attribute() {
+  return ${return_code}
+)
+
+function get_metadata_attribute() (
   set +x
   local -r attribute_name="$1"
   local -r default_value="${2:-}"
   get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
-  set -x
-}
+)
 
 OS_NAME=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
 distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
@@ -117,21 +120,20 @@ readonly ROLE
 
 # CUDA version and Driver version
 # https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html
+# https://developer.nvidia.com/cuda-downloads
 readonly -A DRIVER_FOR_CUDA=(
-          [11.8]="525.147.05" [12.1]="530.30.02"  [12.4]="550.54.14"
-          [12.5]="555.42.06"  [12.6]="560.28.03"
+          [11.8]="525.147.05" [12.4]="550.54.14"  [12.6]="560.35.03"
 )
+# https://developer.nvidia.com/cudnn-downloads
 readonly -A CUDNN_FOR_CUDA=(
-          [11.8]="8.6.0.163"  [12.1]="8.9.0"      [12.4]="9.1.0.70"
-          [12.5]="9.2.1.18"
+          [11.8]="9.5.1.17"   [12.4]="9.5.1.17"   [12.6]="9.5.1.17"
 )
+# https://developer.nvidia.com/nccl/nccl-download
 readonly -A NCCL_FOR_CUDA=(
-          [11.8]="2.15.5"     [12.1]="2.17.1"     [12.4]="2.21.5"
-          [12.5]="2.22.3"
+          [11.8]="2.15.5"     [12.4]="2.23.4"     [12.6]="2.23.4"
 )
 readonly -A CUDA_SUBVER=(
-          [11.8]="11.8.0"     [12.1]="12.1.0"     [12.4]="12.4.1"
-          [12.5]="12.5.1"
+          [11.8]="11.8.0"     [12.4]="12.4.1"     [12.6]="12.6.2"
 )
 
 RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'SPARK')
@@ -140,8 +142,8 @@ CUDA_VERSION=$(get_metadata_attribute 'cuda-version' "${DEFAULT_CUDA_VERSION}")
 readonly CUDA_VERSION
 readonly CUDA_FULL_VERSION="${CUDA_SUBVER["${CUDA_VERSION}"]}"
 
-function is_cuda12() { [[ "${CUDA_VERSION%%.*}" == "12" ]] ; }
-function is_cuda11() { [[ "${CUDA_VERSION%%.*}" == "11" ]] ; }
+function is_cuda12() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "12" ]] ; )
+function is_cuda11() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "11" ]] ; )
 readonly DEFAULT_DRIVER=${DRIVER_FOR_CUDA["${CUDA_VERSION}"]}
 DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
 if is_debian11 || is_ubuntu22 || is_ubuntu20 ; then DRIVER_VERSION="560.28.03" ; fi
@@ -153,8 +155,8 @@ readonly DRIVER=${DRIVER_VERSION%%.*}
 # Parameters for NVIDIA-provided CUDNN library
 readonly DEFAULT_CUDNN_VERSION=${CUDNN_FOR_CUDA["${CUDA_VERSION}"]}
 CUDNN_VERSION=$(get_metadata_attribute 'cudnn-version' "${DEFAULT_CUDNN_VERSION}")
-function is_cudnn8() { [[ "${CUDNN_VERSION%%.*}" == "8" ]] ; }
-function is_cudnn9() { [[ "${CUDNN_VERSION%%.*}" == "9" ]] ; }
+function is_cudnn8() ( set +x ; [[ "${CUDNN_VERSION%%.*}" == "8" ]] ; )
+function is_cudnn9() ( set +x ; [[ "${CUDNN_VERSION%%.*}" == "9" ]] ; )
 if is_rocky \
    && (compare_versions_lte "${CUDNN_VERSION}" "8.0.5.39") ; then
   CUDNN_VERSION="8.0.5.39"
@@ -213,6 +215,7 @@ readonly -A DEFAULT_NVIDIA_CUDA_URLS=(
   [11.8]="${NVIDIA_BASE_DL_URL}/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
   [12.1]="${NVIDIA_BASE_DL_URL}/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run"
   [12.4]="${NVIDIA_BASE_DL_URL}/cuda/12.4.0/local_installers/cuda_12.4.0_550.54.14_linux.run"
+  [12.6]="${NVIDIA_BASE_DL_URL}/cuda/12.6.2/local_installers/cuda_12.6.2_560.35.03_linux.run"
 )
 readonly DEFAULT_NVIDIA_CUDA_URL=${DEFAULT_NVIDIA_CUDA_URLS["${CUDA_VERSION}"]}
 NVIDIA_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_CUDA_URL}")
@@ -232,7 +235,8 @@ if ( compare_versions_lte "8.3.1.22" "${CUDNN_VERSION}" ); then
 fi
 if ( compare_versions_lte "12.0" "${CUDA_VERSION}" ); then
   # When cuda version is greater than 12.0
-  CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.2.0.82_cuda12-archive.tar.xz"
+  CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda12-archive.tar.xz"
+  CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/cudnn/redist/cudnn/linux-x86_64/${CUDNN_TARBALL}"
 fi
 readonly CUDNN_TARBALL
 readonly CUDNN_TARBALL_URL
@@ -256,16 +260,23 @@ NVIDIA_SMI_PATH='/usr/bin'
 MIG_MAJOR_CAPS=0
 IS_MIG_ENABLED=0
 
-function execute_with_retries() {
+function execute_with_retries() (
   set +x
   local -r cmd="$*"
+
+  if [[ "$cmd" =~ "^apt-get install" ]] ; then
+    apt-get -y clean
+    apt-get -y autoremove
+  fi
   for ((i = 0; i < 3; i++)); do
-    if eval "$cmd"; then set -x ; return 0 ; fi
+    set -x
+    time eval "$cmd" > "${install_log}" 2>&1 && retval=$? || { retval=$? ; cat "${install_log}" ; }
+    set +x
+    if [[ $retval == 0 ]] ; then return 0 ; fi
     sleep 5
   done
-  set -x
   return 1
-}
+)
 
 CUDA_KEYRING_PKG_INSTALLED="0"
 function install_cuda_keyring_pkg() {
@@ -273,9 +284,9 @@ function install_cuda_keyring_pkg() {
   local kr_ver=1.1
   curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
     "${NVIDIA_REPO_URL}/cuda-keyring_${kr_ver}-1_all.deb" \
-    -o /tmp/cuda-keyring.deb
-  dpkg -i "/tmp/cuda-keyring.deb"
-  rm -f "/tmp/cuda-keyring.deb"
+    -o "${tmpdir}/cuda-keyring.deb"
+  dpkg -i "${tmpdir}/cuda-keyring.deb"
+  rm -f "${tmpdir}/cuda-keyring.deb"
   CUDA_KEYRING_PKG_INSTALLED="1"
 }
 
@@ -295,10 +306,10 @@ function install_local_cuda_repo() {
   readonly DIST_KEYRING_DIR="/var/${pkgname}"
 
   curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
-    "${LOCAL_DEB_URL}" -o "/tmp/${LOCAL_INSTALLER_DEB}"
+    "${LOCAL_DEB_URL}" -o "${tmpdir}/${LOCAL_INSTALLER_DEB}"
 
-  dpkg -i "/tmp/${LOCAL_INSTALLER_DEB}"
-  rm "/tmp/${LOCAL_INSTALLER_DEB}"
+  dpkg -i "${tmpdir}/${LOCAL_INSTALLER_DEB}"
+  rm "${tmpdir}/${LOCAL_INSTALLER_DEB}"
   cp ${DIST_KEYRING_DIR}/cuda-*-keyring.gpg /usr/share/keyrings/
 
   if is_ubuntu ; then
@@ -323,11 +334,11 @@ function install_local_cudnn_repo() {
 
   # ${NVIDIA_BASE_DL_URL}/redist/cudnn/v8.6.0/local_installers/11.8/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz
   curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
-    "${local_deb_url}" -o /tmp/local-installer.deb
+    "${local_deb_url}" -o "${tmpdir}/local-installer.deb"
 
-  dpkg -i /tmp/local-installer.deb
+  dpkg -i "${tmpdir}/local-installer.deb"
 
-  rm -f /tmp/local-installer.deb
+  rm -f "${tmpdir}/local-installer.deb"
 
   cp /var/cudnn-local-repo-*-${CUDNN}*/cudnn-local-*-keyring.gpg /usr/share/keyrings
 
@@ -354,8 +365,9 @@ function install_local_cudnn8_repo() {
   pkgname="cudnn-local-repo-${cudnn8_shortname}-${CUDNN_VERSION}"
   CUDNN8_PKG_NAME="${pkgname}"
 
-  local_deb_fn="${pkgname}_1.0-1_amd64.deb"
-  local_deb_url="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN}/local_installers/${CUDNN8_CUDA_VER}/${local_deb_fn}"
+  deb_fn="${pkgname}_1.0-1_amd64.deb"
+  local_deb_fn="${tmpdir}/${deb_fn}"
+  local_deb_url="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN}/local_installers/${CUDNN8_CUDA_VER}/${deb_fn}"
   curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
       "${local_deb_url}" -o "${local_deb_fn}"
 
@@ -376,22 +388,25 @@ function install_nvidia_nccl() {
   local -r nccl_version="${NCCL_VERSION}-1+cuda${CUDA_VERSION}"
 
   if is_rocky ; then
-    time execute_with_retries \
+    execute_with_retries \
       dnf -y -q install \
         "libnccl-${nccl_version}" "libnccl-devel-${nccl_version}" "libnccl-static-${nccl_version}"
+    sync
   elif is_ubuntu ; then
     install_cuda_keyring_pkg
 
     apt-get update -qq
 
     if is_ubuntu18 ; then
-      time execute_with_retries \
+      execute_with_retries \
         apt-get install -q -y \
           libnccl2 libnccl-dev
+      sync
     else
-      time execute_with_retries \
+      execute_with_retries \
         apt-get install -q -y \
           "libnccl2=${nccl_version}" "libnccl-dev=${nccl_version}"
+      sync
     fi
   else
     echo "Unsupported OS: '${OS_NAME}'"
@@ -403,8 +418,8 @@ function install_nvidia_nccl() {
   fi
 }
 
-function is_src_nvidia() { [[ "${GPU_DRIVER_PROVIDER}" == "NVIDIA" ]] ; }
-function is_src_os()     { [[ "${GPU_DRIVER_PROVIDER}" == "OS" ]] ; }
+function is_src_nvidia() ( set +x ; [[ "${GPU_DRIVER_PROVIDER}" == "NVIDIA" ]] ; )
+function is_src_os()     ( set +x ; [[ "${GPU_DRIVER_PROVIDER}" == "OS" ]] ; )
 
 function install_nvidia_cudnn() {
   local major_version
@@ -414,17 +429,19 @@ function install_nvidia_cudnn() {
 
   if is_rocky ; then
     if is_cudnn8 ; then
-      execute_with_retries "dnf -y -q install" \
+      execute_with_retries dnf -y -q install \
         "libcudnn${major_version}" \
         "libcudnn${major_version}-devel"
+      sync
     elif is_cudnn9 ; then
-      execute_with_retries "dnf -y -q install" \
+      execute_with_retries dnf -y -q install \
         "libcudnn9-static-cuda-${CUDA_VERSION%%.*}" \
         "libcudnn9-devel-cuda-${CUDA_VERSION%%.*}"
+      sync
     else
       echo "Unsupported cudnn version: '${major_version}'"
     fi
-  elif is_debian || is_ubuntu; then
+  elif is_debuntu; then
     if is_debian12 && is_src_os ; then
       apt-get -y install nvidia-cudnn
     else
@@ -438,6 +455,7 @@ function install_nvidia_cudnn() {
           apt-get -y install --no-install-recommends \
             "libcudnn8=${cudnn_pkg_version}" \
             "libcudnn8-dev=${cudnn_pkg_version}"
+	sync
       elif is_cudnn9 ; then
 	install_cuda_keyring_pkg
 
@@ -448,6 +466,7 @@ function install_nvidia_cudnn() {
           "libcudnn9-cuda-${CUDA_VERSION%%.*}" \
           "libcudnn9-dev-cuda-${CUDA_VERSION%%.*}" \
           "libcudnn9-static-cuda-${CUDA_VERSION%%.*}"
+	sync
       else
         echo "Unsupported cudnn version: [${CUDNN_VERSION}]"
       fi
@@ -458,7 +477,8 @@ function install_nvidia_cudnn() {
       "libcudnn${major_version}=${cudnn_pkg_version}"
       "libcudnn${major_version}-dev=${cudnn_pkg_version}")
     execute_with_retries \
-      "apt-get install -q -y --no-install-recommends ${packages[*]}"
+      apt-get install -q -y --no-install-recommends "${packages[*]}"
+    sync
   else
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
@@ -579,7 +599,7 @@ function add_nonfree_components() {
 }
 
 function add_repo_nvidia_container_toolkit() {
-  if is_debian || is_ubuntu ; then
+  if is_debuntu ; then
       local kr_path=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
       local sources_list_path=/etc/apt/sources.list.d/nvidia-container-toolkit.list
       # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
@@ -595,10 +615,10 @@ function add_repo_nvidia_container_toolkit() {
 }
 
 function add_repo_cuda() {
-  if is_debian || is_ubuntu ; then
+  if is_debuntu ; then
     local kr_path=/usr/share/keyrings/cuda-archive-keyring.gpg
     local sources_list_path="/etc/apt/sources.list.d/cuda-${shortname}-x86_64.list"
-echo "deb [signed-by=${kr_path}] https://developer.download.nvidia.com/compute/cuda/repos/${shortname}/x86_64/ /" \
+    echo "deb [signed-by=${kr_path}] https://developer.download.nvidia.com/compute/cuda/repos/${shortname}/x86_64/ /" \
     | sudo tee "${sources_list_path}"
     curl "${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64/cuda-archive-keyring.gpg" \
       -o "${kr_path}"
@@ -624,8 +644,7 @@ function build_driver_from_github() {
     tarball_fn="${DRIVER_VERSION}.tar.gz"
     curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
       "https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${tarball_fn}" \
-      -o "${tarball_fn}"
-    tar xzf "${tarball_fn}"
+      | tar xz
     mv "open-gpu-kernel-modules-${DRIVER_VERSION}" open-gpu-kernel-modules
   }
   cd open-gpu-kernel-modules
@@ -633,6 +652,7 @@ function build_driver_from_github() {
   time make -j$(nproc) modules \
     >  /var/log/open-gpu-kernel-modules-build.log \
     2> /var/log/open-gpu-kernel-modules-build_error.log
+  sync
 
   if [[ -n "${PSN}" ]]; then
     #configure_dkms_certs
@@ -669,38 +689,41 @@ function build_driver_from_packages() {
     fi
     add_contrib_component
     apt-get update -qq
-    execute_with_retries "apt-get install -y -qq --no-install-recommends dkms"
+    execute_with_retries apt-get install -y -qq --no-install-recommends dkms
     #configure_dkms_certs
-    time execute_with_retries "apt-get install -y -qq --no-install-recommends ${pkglist[@]}"
+    execute_with_retries apt-get install -y -qq --no-install-recommends "${pkglist[@]}"
+    sync
 
   elif is_rocky ; then
     #configure_dkms_certs
     if execute_with_retries dnf -y -q module install "nvidia-driver:${DRIVER}-dkms" ; then
       echo "nvidia-driver:${DRIVER}-dkms installed successfully"
     else
-      time execute_with_retries dnf -y -q module install 'nvidia-driver:latest'
+      execute_with_retries dnf -y -q module install 'nvidia-driver:latest'
     fi
+    sync
   fi
   #clear_dkms_key
 }
 
 function install_nvidia_userspace_runfile() {
-  if test -d /run/nvidia-userspace ; then return ; fi
+  if test -f "${tmpdir}/userspace-complete" ; then return ; fi
   curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
-    "${USERSPACE_URL}" -o userspace.run
-  time bash "./userspace.run" --no-kernel-modules --silent --install-libglvnd \
-    > /dev/null 2>&1
-  rm -f userspace.run
-  mkdir -p /run/nvidia-userspace
+    "${USERSPACE_URL}" -o "${tmpdir}/userspace.run"
+  execute_with_retries bash "${tmpdir}/userspace.run" --no-kernel-modules --silent --install-libglvnd --tmpdir="${tmpdir}"
+  rm -f "${tmpdir}/userspace.run"
+  touch "${tmpdir}/userspace-complete"
+  sync
 }
 
 function install_cuda_runfile() {
-  if test -d /run/nvidia-cuda ; then return ; fi
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
-    "${NVIDIA_CUDA_URL}" -o cuda.run
-  time bash "./cuda.run" --silent --toolkit --no-opengl-libs
-  rm -f cuda.run
-  mkdir -p /run/nvidia-cuda
+  if test -f "${tmpdir}/cuda-complete" ; then return ; fi
+  time curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+    "${NVIDIA_CUDA_URL}" -o "${tmpdir}/cuda.run"
+  execute_with_retries bash "${tmpdir}/cuda.run" --silent --toolkit --no-opengl-libs --tmpdir="${tmpdir}"
+  rm -f "${tmpdir}/cuda.run"
+  touch "${tmpdir}/cuda-complete"
+  sync
 }
 
 function install_cuda_toolkit() {
@@ -712,29 +735,14 @@ function install_cuda_toolkit() {
   fi
   cuda_package="cuda=${CUDA_FULL_VERSION}-1"
   readonly cudatk_package
-  if is_ubuntu || is_debian ; then
+  if is_debuntu ; then
 #    if is_ubuntu ; then execute_with_retries "apt-get install -y -qq --no-install-recommends cuda-drivers-${DRIVER}=${DRIVER_VERSION}-1" ; fi
-    time execute_with_retries "apt-get install -y -qq --no-install-recommends ${cuda_package} ${cudatk_package}"
+    execute_with_retries apt-get install -y -qq --no-install-recommends ${cuda_package} ${cudatk_package}
+     sync
   elif is_rocky ; then
-    time execute_with_retries "dnf -y -q install ${cudatk_package}"
+    execute_with_retries dnf -y -q install "${cudatk_package}"
+    sync
   fi
-}
-
-function install_drivers_aliases() {
-  if is_rocky ; then return ; fi
-  if ! (is_debian12 || is_debian11) ; then return ; fi
-  if (is_debian12 && is_cuda11) && is_src_nvidia ; then return ; fi # don't install on debian 12 / cuda11 with drivers from nvidia
-  # Add a modprobe alias to prefer the open kernel modules
-  local conffile="/etc/modprobe.d/nvidia-aliases.conf"
-  echo -n "" > "${conffile}"
-  local prefix
-  if   is_src_os     ; then prefix="nvidia-current-open"
-  elif is_src_nvidia ; then prefix="nvidia-current" ; fi
-  local suffix
-  for suffix in uvm peermem modeset drm; do
-    echo "alias nvidia-${suffix} ${prefix}-${suffix}" >> "${conffile}"
-  done
-  echo "alias nvidia ${prefix}" >> "${conffile}"
 }
 
 function load_kernel_module() {
@@ -743,9 +751,12 @@ function load_kernel_module() {
     rmmod ${module} > /dev/null 2>&1 || echo "unable to rmmod ${module}"
   done
 
-  install_drivers_aliases
   depmod -a
   modprobe nvidia
+  for suffix in uvm modeset drm; do
+    modprobe "nvidia-${suffix}"
+  done
+  # TODO: if peermem is available, also modprobe nvidia-peermem
 }
 
 # Install NVIDIA GPU driver provided by NVIDIA
@@ -764,22 +775,17 @@ function install_nvidia_gpu_driver() {
           libglvnd0 \
           libcuda1
     #clear_dkms_key
-    load_kernel_module
   elif is_ubuntu18 || is_debian10 || (is_debian12 && is_cuda11) ; then
 
     install_nvidia_userspace_runfile
 
     build_driver_from_github
 
-    load_kernel_module
-
     install_cuda_runfile
-  elif is_debian || is_ubuntu ; then
+  elif is_debuntu ; then
     install_cuda_keyring_pkg
 
     build_driver_from_packages
-
-    load_kernel_module
 
     install_cuda_toolkit
   elif is_rocky ; then
@@ -787,16 +793,17 @@ function install_nvidia_gpu_driver() {
 
     build_driver_from_packages
 
-    load_kernel_module
-
     install_cuda_toolkit
-
   else
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
   fi
   ldconfig
-  echo "NVIDIA GPU driver provided by NVIDIA was installed successfully"
+  if is_src_os ; then
+    echo "NVIDIA GPU driver provided by ${OS_NAME} was installed successfully"
+  else
+    echo "NVIDIA GPU driver provided by NVIDIA was installed successfully"
+  fi
 }
 
 # Collects 'gpu_utilization' and 'gpu_memory_utilization' metrics
@@ -812,7 +819,8 @@ function install_gpu_agent() {
     "${GPU_AGENT_REPO_URL}/report_gpu_metrics.py" \
     | sed -e 's/-u --format=/--format=/' \
     | dd status=none of="${install_dir}/report_gpu_metrics.py"
-  pip install -r "${install_dir}/requirements.txt"
+  execute_with_retries pip install -r "${install_dir}/requirements.txt"
+  sync
 
   # Generate GPU service.
   cat <<EOF >/lib/systemd/system/gpu-utilization-agent.service
@@ -837,7 +845,6 @@ EOF
   systemctl --no-reload --now enable gpu-utilization-agent.service
 }
 
-readonly bdcfg="/usr/local/bin/bdconfig"
 function set_hadoop_property() {
   local -r config_file=$1
   local -r property=$2
@@ -991,7 +998,6 @@ EOF
   systemctl start dataproc-cgroup-device-permissions
 }
 
-nvsmi_works="0"
 function nvsmi() {
   local nvsmi="/usr/bin/nvidia-smi"
   if   [[ "${nvsmi_works}" == "1" ]] ; then echo "nvidia-smi is working" >&2
@@ -1018,24 +1024,26 @@ function main() {
 
   remove_old_backports
 
-  if is_debian || is_ubuntu ; then
+  if is_debuntu ; then
     export DEBIAN_FRONTEND=noninteractive
-    execute_with_retries "apt-get install -y -qq pciutils linux-headers-${uname_r}"
+    execute_with_retries apt-get install -y -qq pciutils "linux-headers-${uname_r}"
   elif is_rocky ; then
-    execute_with_retries "dnf -y -q update --exclude=systemd*,kernel*"
-    execute_with_retries "dnf -y -q install pciutils gcc"
+    execute_with_retries dnf -y -q update --exclude=systemd*,kernel*
+    execute_with_retries dnf -y -q install pciutils gcc
 
     local dnf_cmd="dnf -y -q install kernel-devel-${uname_r}"
     local kernel_devel_pkg_out="$(eval "${dnf_cmd} 2>&1")"
     if [[ "${kernel_devel_pkg_out}" =~ 'Unable to find a match: kernel-devel-' ]] ; then
       # this kernel-devel may have been migrated to the vault
-      local vault="https://download.rockylinux.org/vault/rocky/$(os_version)"
+      local os_ver="$(echo $uname_r | perl -pe 's/.*el(\d+_\d+)\..*/$1/; s/_/./')"
+      local vault="https://download.rockylinux.org/vault/rocky/${os_ver}"
       execute_with_retries dnf -y -q --setopt=localpkg_gpgcheck=1 install \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-${uname_r}.rpm" \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-core-${uname_r}.rpm" \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-modules-${uname_r}.rpm" \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-modules-core-${uname_r}.rpm" \
         "${vault}/AppStream/x86_64/os/Packages/k/kernel-devel-${uname_r}.rpm"
+      sync
     else
       execute_with_retries "${dnf_cmd}"
     fi
@@ -1067,6 +1075,8 @@ function main() {
     if [[ $IS_MIG_ENABLED -eq 0 ]]; then
       install_nvidia_gpu_driver
 
+      load_kernel_module
+
       if [[ -n ${CUDNN_VERSION} ]]; then
         install_nvidia_nccl
         install_nvidia_cudnn
@@ -1084,7 +1094,7 @@ function main() {
         rmmod ${module} > /dev/null 2>&1 || echo "unable to rmmod ${module}"
       done
 
-      MIG_GPU_LIST="$(nvsmi -L | grep -e MIG -e H100 -e A100 || echo -n "")"
+      MIG_GPU_LIST="$(nvsmi -L | grep -e MIG -e P100 -e H100 -e A100 || echo -n "")"
       if test -n "$(nvsmi -L)" ; then
 	# cache the result of the gpu query
         ADDRS=$(nvsmi --query-gpu=index --format=csv,noheader | perl -e 'print(join(q{,},map{chomp; qq{"$_"}}<STDIN>))')
@@ -1197,8 +1207,10 @@ function clean_up_sources_lists() {
   # cran-r
   #
   if [[ -f /etc/apt/sources.list.d/cran-r.list ]]; then
+    keyid="0x95c0faf38db3ccad0c080a7bdc78b2ddeabc47b7"
+    if is_ubuntu18 ; then keyid="0x51716619E084DAB9"; fi
     rm -f /usr/share/keyrings/cran-r.gpg
-    curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x95c0faf38db3ccad0c080a7bdc78b2ddeabc47b7' | \
+    curl "https://keyserver.ubuntu.com/pks/lookup?op=get&search=${keyid}" | \
       gpg --dearmor -o /usr/share/keyrings/cran-r.gpg
     sed -i -e 's:deb http:deb [signed-by=/usr/share/keyrings/cran-r.gpg] http:g' /etc/apt/sources.list.d/cran-r.list
   fi
@@ -1213,21 +1225,188 @@ function clean_up_sources_lists() {
     sed -i -e 's:deb https:deb [signed-by=/usr/share/keyrings/mysql.gpg] https:g' /etc/apt/sources.list.d/mysql.list
   fi
 
-  if -f /etc/apt/trusted.gpg ; then mv /etc/apt/trusted.gpg /etc/apt/old-trusted.gpg ; fi
+  if [[ -f /etc/apt/trusted.gpg ]] ; then mv /etc/apt/trusted.gpg /etc/apt/old-trusted.gpg ; fi
 
 }
 
-if is_debian ; then
-  clean_up_sources_lists
-  apt-get update
-  if is_debian12 ; then
-  apt-mark unhold systemd libsystemd0 ; fi
-fi
+function exit_handler() {
+  set +ex
+  echo "Exit handler invoked"
 
-configure_dkms_certs
+  # Purge private key material until next grant
+  clear_dkms_key
+
+  # Clear pip cache
+  pip cache purge || echo "unable to purge pip cache"
+
+  # If system memory was sufficient to mount memory-backed filesystems
+  if [[ "${tmpdir}" == "/mnt/shm" ]] ; then
+    # remove the tmpfs pip cache-dir
+    pip config unset global.cache-dir || echo "unable to unset global pip cache"
+
+    # Clean up shared memory mounts
+    for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm /tmp ; do
+      if grep -q "^tmpfs ${shmdir}" /proc/mounts ; then
+        rm -rf ${shmdir}/*
+        sync
+        sleep 3s
+        umount -f ${shmdir}
+      fi
+    done
+
+    # restart services stopped during preparation stage
+    # systemctl list-units | perl -n -e 'qx(systemctl start $1) if /^.*? ((hadoop|knox|hive|mapred|yarn|hdfs)\S*).service/'
+  fi
+
+  if is_debuntu ; then
+    # Clean up OS package cache
+    apt-get -y -qq clean
+    apt-get -y -qq autoremove
+    # re-hold systemd package
+    if is_debian12 ; then
+    apt-mark hold systemd libsystemd0 ; fi
+  else
+    dnf clean all
+  fi
+
+  # print disk usage statistics for large components
+  if is_ubuntu ; then
+    du -hs \
+      /usr/lib/{pig,hive,hadoop,jvm,spark,google-cloud-sdk,x86_64-linux-gnu} \
+      /usr/lib \
+      /opt/nvidia/* \
+      /usr/local/cuda-1?.? \
+      /opt/conda/miniconda3 | sort -h
+  elif is_debian ; then
+    du -hs \
+      /usr/lib/{pig,hive,hadoop,jvm,spark,google-cloud-sdk,x86_64-linux-gnu} \
+      /usr/lib \
+      /usr/local/cuda-1?.? \
+      /opt/conda/miniconda3 | sort -h
+  else
+    du -hs \
+      /var/lib/docker \
+      /usr/lib/{pig,hive,hadoop,firmware,jvm,spark,atlas} \
+      /usr/lib64/google-cloud-sdk \
+      /usr/lib \
+      /opt/nvidia/* \
+      /usr/local/cuda-1?.? \
+      /opt/conda/miniconda3
+  fi
+
+  # Process disk usage logs from installation period
+  rm -f /run/keep-running-df
+  sync
+  sleep 5.01s
+  # compute maximum size of disk during installation
+  # Log file contains logs like the following (minus the preceeding #):
+#Filesystem     1K-blocks    Used Available Use% Mounted on
+#/dev/vda2        7096908 2611344   4182932  39% /
+  df / | tee -a "/run/disk-usage.log"
+
+  perl -e '@siz=( sort { $a => $b }
+                   map { (split)[2] =~ /^(\d+)/ }
+                  grep { m:^/: } <STDIN> );
+$max=$siz[0]; $min=$siz[-1]; $inc=$max-$min;
+print( "    samples-taken: ", scalar @siz, $/,
+       "maximum-disk-used: $max", $/,
+       "minimum-disk-used: $min", $/,
+       "     increased-by: $inc", $/ )' < "/run/disk-usage.log"
+
+  echo "exit_handler has completed"
+
+  # zero free disk space
+  if [[ -n "$(get_metadata_attribute creating-image)" ]]; then
+    dd if=/dev/zero of=/zero
+    sync
+    sleep 3s
+    rm -f /zero
+  fi
+
+  return 0
+}
+
+function set_proxy(){
+  export METADATA_HTTP_PROXY="$(get_metadata_attribute http-proxy)"
+  export http_proxy="${METADATA_HTTP_PROXY}"
+  export https_proxy="${METADATA_HTTP_PROXY}"
+  export HTTP_PROXY="${METADATA_HTTP_PROXY}"
+  export HTTPS_PROXY="${METADATA_HTTP_PROXY}"
+  export no_proxy=metadata.google.internal,169.254.169.254
+  export NO_PROXY=metadata.google.internal,169.254.169.254
+}
+
+function prepare_to_install(){
+  nvsmi_works="0"
+  readonly bdcfg="/usr/local/bin/bdconfig"
+  tmpdir=/tmp/
+  local free_mem
+  trap exit_handler EXIT
+  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
+  # Write to a ramdisk instead of churning the persistent disk
+  if [[ ${free_mem} -ge 10500000 ]]; then
+
+    # Services might use /tmp for temporary files - if we see errors,
+    # consider uncommenting the following command to stop them during
+    # install
+
+    # systemctl list-units | perl -n -e 'qx(systemctl stop $1) if /^.*? ((hadoop|knox|hive|mapred|yarn|hdfs)\S*).service/'
+    sudo mount -t tmpfs tmpfs /tmp
+
+    tmpdir="/mnt/shm"
+    mkdir -p "${tmpdir}"
+    mount -t tmpfs tmpfs "${tmpdir}"
+
+    # Clear pip cache
+    pip cache purge || echo "unable to purge pip cache"
+
+    # Download pip packages to tmpfs
+    pip config set global.cache-dir "${tmpdir}" || echo "unable to set global.cache-dir"
+
+    # Download OS packages to tmpfs
+    if is_debuntu ; then
+      mount -t tmpfs tmpfs /var/cache/apt/archives
+    else
+      mount -t tmpfs tmpfs /var/cache/dnf
+    fi
+  else
+    tmpdir=/tmp
+  fi
+  install_log="${tmpdir}/install.log"
+
+  set_proxy
+
+  if is_debuntu ; then
+    clean_up_sources_lists
+    apt-get update -qq
+    apt-get -y clean
+    sleep 5s
+    apt-get -y -qq autoremove
+    if is_debian12 ; then
+    apt-mark unhold systemd libsystemd0 ; fi
+  else
+    dnf clean all
+  fi
+
+  # zero free disk space
+  if [[ -n "$(get_metadata_attribute creating-image)" ]]; then ( set +e
+    time dd if=/dev/zero of=/zero status=none ; sync ; sleep 3s ; rm -f /zero
+  ) fi
+
+  configure_dkms_certs
+
+  # Monitor disk usage in a screen session
+  if is_debuntu ; then
+      execute_with_retries apt-get install -y -qq screen
+  else
+      execute_with_retries dnf -y -q install screen
+  fi
+  df / > "/run/disk-usage.log"
+  touch "/run/keep-running-df"
+  screen -d -m -US keep-running-df \
+    bash -c "while [[ -f /run/keep-running-df ]] ; do df / | tee -a /run/disk-usage.log ; sleep 5s ; done"
+}
+
+prepare_to_install
 
 main
-
-clear_dkms_key
-
-df -h

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -172,8 +172,8 @@ function ge_cuda11() ( set +x ; version_ge "${CUDA_VERSION}" "11" ; )
 
 readonly DEFAULT_DRIVER=${DRIVER_FOR_CUDA["${CUDA_VERSION}"]}
 DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
-if is_debian11 || ge_ubuntu20 ; then DRIVER_VERSION="560.28.03" ; fi
-if is_ubuntu20 && le_cuda11 ; then DRIVER_VERSION="535.183.06" ; fi
+if ( is_debian11 || ge_ubuntu20 ) ; then DRIVER_VERSION="560.28.03" ; fi
+if ( is_ubuntu20 && le_cuda11 )   ; then DRIVER_VERSION="535.183.06" ; fi
 
 readonly DRIVER_VERSION
 readonly DRIVER=${DRIVER_VERSION%%.*}
@@ -239,13 +239,14 @@ NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}
 readonly NCCL_REPO_URL
 readonly NCCL_REPO_KEY="${NVIDIA_BASE_DL_URL}/machine-learning/repos/${nccl_shortname}/x86_64/7fa2af80.pub" # 3bf863cc.pub
 
-function set_cuda_runfile_url() {_
+function set_cuda_runfile_url() {
   local RUNFILE_DRIVER_VERSION="${DRIVER_VERSION}"
   local RUNFILE_CUDA_VERSION="${CUDA_FULL_VERSION}"
+
   if ( ge_cuda12 && (le_debian11 || le_ubuntu18) ) ; then
     RUNFILE_DRIVER_VERSION="525.60.13"
     RUNFILE_CUDA_VERSION="12.0.0"
-  elif lt_cuda12
+  elif lt_cuda12 ; then
     RUNFILE_DRIVER_VERSION="520.61.05"
     RUNFILE_CUDA_VERSION="11.8.0"
   fi

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1253,11 +1253,8 @@ function exit_handler() {
     pip config unset global.cache-dir || echo "unable to unset global pip cache"
 
     # Clean up shared memory mounts
-    for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm ; do
-      if grep -q "^tmpfs ${shmdir}" /proc/mounts ; then
-        rm -rf ${shmdir}/*
-        sync
-        sleep 3s
+    for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm /tmp ; do
+      if grep -q "^tmpfs ${shmdir}" /proc/mounts && ! grep -q "^tmpfs ${shmdir}" /etc/fstab ; then
         umount -f ${shmdir}
       fi
     done

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -129,26 +129,35 @@ readonly ROLE
 # https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html
 # https://developer.nvidia.com/cuda-downloads
 readonly -A DRIVER_FOR_CUDA=(
-          [11.8]="560.35.03" [12.4]="560.35.03"  [12.6]="560.35.03"
+          [11.8]="560.35.03"
+          [12.0]="525.60.13"  [12.4]="560.35.03"  [12.6]="560.35.03"
 )
 # https://developer.nvidia.com/cudnn-downloads
 readonly -A CUDNN_FOR_CUDA=(
-          [11.8]="9.5.1.17"   [12.4]="9.5.1.17"   [12.6]="9.5.1.17"
+          [11.8]="9.5.1.17"
+          [12.0]="9.5.1.17"   [12.4]="9.5.1.17"   [12.6]="9.5.1.17"
 )
 # https://developer.nvidia.com/nccl/nccl-download
 readonly -A NCCL_FOR_CUDA=(
-          [11.8]="2.15.5"     [12.4]="2.23.4"     [12.6]="2.23.4"
+          [11.8]="2.15.5"
+          [12.0]="2.23.4"  [12.4]="2.23.4"     [12.6]="2.23.4"
 )
 readonly -A CUDA_SUBVER=(
-          [11.8]="11.8.0"     [12.4]="12.4.1"     [12.6]="12.6.2"
+          [11.8]="11.8.0"
+          [12.0]="12.0.0"  [12.4]="12.4.1"     [12.6]="12.6.2"
 )
 
 RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'SPARK')
 readonly DEFAULT_CUDA_VERSION='12.4'
 CUDA_VERSION=$(get_metadata_attribute 'cuda-version' "${DEFAULT_CUDA_VERSION}")
-# CUDA 11 no longer supported on debian12 - 2024-11-22
-if ge_debian12 && version_le "${CUDA_VERSION%%.*}" "11" ; then
+if ( ge_debian12 && version_le "${CUDA_VERSION%%.*}" "11" ) ; then
+  # CUDA 11 no longer supported on debian12 - 2024-11-22
   CUDA_VERSION="${DEFAULT_CUDA_VERSION}"
+fi
+
+if ( version_ge "${CUDA_VERSION}" "12" && (le_debian11 || le_ubuntu18) ) ; then
+  # Only CUDA 12.0 supported on older debuntu
+  CUDA_VERSION="12.0"
 fi
 readonly CUDA_VERSION
 readonly CUDA_FULL_VERSION="${CUDA_SUBVER["${CUDA_VERSION}"]}"

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -19,18 +19,29 @@ set -euxo pipefail
 function os_id()       ( set +x ;  grep '^ID=' /etc/os-release | cut -d= -f2 | xargs ; )
 function os_version()  ( set +x ;  grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | xargs ; )
 function os_codename() ( set +x ;  grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs ; )
-function is_rocky()    ( set +x ;  [[ "$(os_id)" == 'rocky' ]] ; )
-function is_rocky8()   ( set +x ;  is_rocky && [[ "$(os_version)" == '8'* ]] ; )
-function is_rocky9()   ( set +x ;  is_rocky && [[ "$(os_version)" == '9'* ]] ; )
-function is_ubuntu()   ( set +x ;  [[ "$(os_id)" == 'ubuntu' ]] ; )
-function is_ubuntu18() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '18.04'* ]] ; )
-function is_ubuntu20() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '20.04'* ]] ; )
-function is_ubuntu22() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '22.04'* ]] ; )
-function is_debian()   ( set +x ;  [[ "$(os_id)" == 'debian' ]] ; )
-function is_debian10() ( set +x ;  is_debian && [[ "$(os_version)" == '10'* ]] ; )
-function is_debian11() ( set +x ;  is_debian && [[ "$(os_version)" == '11'* ]] ; )
-function is_debian12() ( set +x ;  is_debian && [[ "$(os_version)" == '12'* ]] ; )
-function is_debuntu()  ( set +x ;  is_debian || is_ubuntu ; )
+
+function version_ge() ( set +x ;  [ "$1" = "$(echo -e "$1\n$2" | sort -V | tail -n1)" ] ; )
+function version_gt() ( set +x ;  [ "$1" = "$2" ] && return 1 || version_ge $1 $2 ; )
+function version_le() ( set +x ;  [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ] ; )
+function version_lt() ( set +x ;  [ "$1" = "$2" ] && return 1 || version_le $1 $2 ; )
+
+readonly -A supported_os=(
+  ['debian']=('10' '11' '12')
+  ['ubuntu']=('18.04' '20.04' '22.04')
+  ['rocky']=('8' '9')
+)
+
+# dynamically define OS version test utility functions
+for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
+  eval "function is_${os_id_val}() ( set +x ;  [[ \"\$(os_id)\" == '${os_id_val}' ]] ; )"
+
+  supported_versions=${supported_os["${os_id_val}"]}
+  for osver in "${supported_versions[@]}"; do
+    eval "function is_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && [[ \"\$(os_version)\" == '${osver}'* ]] ; )"
+    eval "function ge_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_ge \"\$(os_version)\" '${osver}' ; )"
+    eval "function le_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_le \"\$(os_version)\" '${osver}' ; )"
+  done
+done
 
 function os_vercat()   ( set +x
   if   is_ubuntu ; then os_version | sed -e 's/[^0-9]//g'
@@ -38,8 +49,7 @@ function os_vercat()   ( set +x
                    else os_version ; fi ; )
 
 function remove_old_backports {
-  if ! is_debuntu ; then  return ; fi
-  if is_debian12 ; then return ; fi
+  if ge_debian12 || ! is_debuntu ; then return ; fi
   # This script uses 'apt-get update' and is therefore potentially dependent on
   # backports repositories which have been archived.  In order to mitigate this
   # problem, we will use archive.debian.org for the oldoldstable repo
@@ -58,14 +68,6 @@ function remove_old_backports {
                   {\$1 https://archive.debian.org/debian ${oldoldstable}-backports }g" "${filename}"
   done
 }
-
-# Return true if the first argument is equal to or less than the second argument
-function compare_versions_lte { [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ] ; }
-
-# Return true if the first argument is less than the second argument
-function compare_versions_lt() ( set +x
-  [ "$1" = "$2" ] && return 1 || compare_versions_lte $1 $2
-)
 
 function print_metadata_value() {
   local readonly tmpfile=$(mktemp)
@@ -144,11 +146,17 @@ readonly CUDA_VERSION
 readonly CUDA_FULL_VERSION="${CUDA_SUBVER["${CUDA_VERSION}"]}"
 
 function is_cuda12() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "12" ]] ; )
+function le_cuda12() ( set +x ; version_le "${CUDA_VERSION}" "12" ; )
+function ge_cuda12() ( set +x ; version_ge "${CUDA_VERSION}" "12" ; )
+
 function is_cuda11() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "11" ]] ; )
+function le_cuda11() ( set +x ; version_le "${CUDA_VERSION}" "11" ; )
+function ge_cuda11() ( set +x ; version_ge "${CUDA_VERSION}" "11" ; )
+
 readonly DEFAULT_DRIVER=${DRIVER_FOR_CUDA["${CUDA_VERSION}"]}
 DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
-if is_debian11 || is_ubuntu22 || is_ubuntu20 ; then DRIVER_VERSION="560.28.03" ; fi
-if is_ubuntu20 && is_cuda11 ; then DRIVER_VERSION="535.183.06" ; fi
+if is_debian11 || ge_ubuntu20 ; then DRIVER_VERSION="560.28.03" ; fi
+if is_ubuntu20 && le_cuda11 ; then DRIVER_VERSION="535.183.06" ; fi
 
 readonly DRIVER_VERSION
 readonly DRIVER=${DRIVER_VERSION%%.*}
@@ -158,14 +166,12 @@ readonly DEFAULT_CUDNN_VERSION=${CUDNN_FOR_CUDA["${CUDA_VERSION}"]}
 CUDNN_VERSION=$(get_metadata_attribute 'cudnn-version' "${DEFAULT_CUDNN_VERSION}")
 function is_cudnn8() ( set +x ; [[ "${CUDNN_VERSION%%.*}" == "8" ]] ; )
 function is_cudnn9() ( set +x ; [[ "${CUDNN_VERSION%%.*}" == "9" ]] ; )
-if is_rocky \
-   && (compare_versions_lte "${CUDNN_VERSION}" "8.0.5.39") ; then
+if is_rocky  && (version_le "${CUDNN_VERSION}" "8.0.5.39") ; then
   CUDNN_VERSION="8.0.5.39"
-elif (is_ubuntu20 || is_ubuntu22 || is_debian12) && is_cudnn8 ; then
+elif (ge_ubuntu20 || ge_debian12) && is_cudnn8 ; then
   # cuDNN v8 is not distribution for ubuntu20+, debian12
   CUDNN_VERSION="9.1.0.70"
-
-elif (is_ubuntu18 || is_debian10 || is_debian11) && is_cudnn9 ; then
+elif (le_ubuntu18 || le_debian11) && is_cudnn9 ; then
   # cuDNN v9 is not distributed for ubuntu18, debian10, debian11 ; fall back to 8
   CUDNN_VERSION="8.8.0.121"
 fi
@@ -188,7 +194,7 @@ if is_ubuntu22  ; then
 
     nccl_shortname="ubuntu2004"
     shortname="$(os_id)$(os_vercat)"
-elif is_rocky9 ; then
+elif ge_rocky9 ; then
     # use packages from previous release until such time as nvidia
     # release rhel9 builds
 
@@ -227,14 +233,14 @@ readonly NVIDIA_ROCKY_REPO_URL="${NVIDIA_REPO_URL}/cuda-${shortname}.repo"
 
 CUDNN_TARBALL="cudnn-${CUDA_VERSION}-linux-x64-v${CUDNN_VERSION}.tgz"
 CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN_VERSION%.*}/${CUDNN_TARBALL}"
-if ( compare_versions_lte "8.3.1.22" "${CUDNN_VERSION}" ); then
+if ( version_ge "${CUDNN_VERSION}" "8.3.1.22" ); then
   CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda${CUDA_VERSION%.*}-archive.tar.xz"
-  if ( compare_versions_lte "${CUDNN_VERSION}" "8.4.1.50" ); then
+  if ( version_le "${CUDNN_VERSION}" "8.4.1.50" ); then
     CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda${CUDA_VERSION}-archive.tar.xz"
   fi
   CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN_VERSION%.*}/local_installers/${CUDA_VERSION}/${CUDNN_TARBALL}"
 fi
-if ( compare_versions_lte "12.0" "${CUDA_VERSION}" ); then
+if ( version_ge "${CUDA_VERSION}" "12.0" ); then
   # When cuda version is greater than 12.0
   CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda12-archive.tar.xz"
   CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/cudnn/redist/cudnn/linux-x86_64/${CUDNN_TARBALL}"
@@ -443,7 +449,7 @@ function install_nvidia_cudnn() {
       echo "Unsupported cudnn version: '${major_version}'"
     fi
   elif is_debuntu; then
-    if is_debian12 && is_src_os ; then
+    if ge_debian12 && is_src_os ; then
       apt-get -y install nvidia-cudnn
     else
       local CUDNN="${CUDNN_VERSION%.*}"
@@ -575,7 +581,7 @@ function clear_dkms_key {
 }
 
 function add_contrib_component() {
-  if is_debian12 ; then
+  if ge_debian12 ; then
       # Include in sources file components on which nvidia-kernel-open-dkms depends
       local -r debian_sources="/etc/apt/sources.list.d/debian.sources"
       local components="main contrib"
@@ -588,7 +594,7 @@ function add_contrib_component() {
 
 function add_nonfree_components() {
   if is_src_nvidia ; then return; fi
-  if is_debian12 ; then
+  if ge_debian12 ; then
       # Include in sources file components on which nvidia-open-kernel-dkms depends
       local -r debian_sources="/etc/apt/sources.list.d/debian.sources"
       local components="main contrib non-free non-free-firmware"
@@ -673,7 +679,7 @@ function build_driver_from_github() {
 }
 
 function build_driver_from_packages() {
-  if is_ubuntu || is_debian ; then
+  if is_debuntu ; then
     if [[ -n "$(apt-cache search -n "nvidia-driver-${DRIVER}-server-open")" ]] ; then
       local pkglist=("nvidia-driver-${DRIVER}-server-open") ; else
       local pkglist=("nvidia-driver-${DRIVER}-open") ; fi
@@ -729,7 +735,7 @@ function install_cuda_runfile() {
 
 function install_cuda_toolkit() {
   local cudatk_package=cuda-toolkit
-  if is_debian12 && is_src_os ; then
+  if ge_debian12 && is_src_os ; then
     cudatk_package="${cudatk_package}=${CUDA_FULL_VERSION}-1"
   elif [[ -n "${CUDA_VERSION}" ]]; then
     cudatk_package="${cudatk_package}-${CUDA_VERSION//./-}"
@@ -762,7 +768,7 @@ function load_kernel_module() {
 
 # Install NVIDIA GPU driver provided by NVIDIA
 function install_nvidia_gpu_driver() {
-  if is_debian12 && is_src_os ; then
+  if ge_debian12 && is_src_os ; then
     add_nonfree_components
     add_repo_nvidia_container_toolkit
     apt-get update -qq
@@ -776,7 +782,7 @@ function install_nvidia_gpu_driver() {
           libglvnd0 \
           libcuda1
     #clear_dkms_key
-  elif is_ubuntu18 || is_debian10 || (is_debian12 && is_cuda11) ; then
+  elif le_ubuntu18 || le_debian10 || (ge_debian12 && le_cuda11) ; then
 
     install_nvidia_userspace_runfile
 
@@ -1257,7 +1263,7 @@ function exit_handler() {
     apt-get -y -qq clean
     apt-get -y -qq autoremove
     # re-hold systemd package
-    if is_debian12 ; then
+    if ge_debian12 ; then
     apt-mark hold systemd libsystemd0 ; fi
   else
     dnf clean all
@@ -1330,6 +1336,32 @@ function set_proxy(){
   export NO_PROXY=metadata.google.internal,169.254.169.254
 }
 
+function mount_ramdisk(){
+  local free_mem
+  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
+  if [[ ${free_mem} -lt 10500000 ]]; then return 0 ; fi
+
+  # Write to a ramdisk instead of churning the persistent disk
+
+  tmpdir="/mnt/shm"
+  mkdir -p "${tmpdir}"
+  mount -t tmpfs tmpfs "${tmpdir}"
+
+  # Clear pip cache
+  # TODO: make this conditional on which OSs have pip without cache purge
+  pip cache purge || echo "unable to purge pip cache"
+
+  # Download pip packages to tmpfs
+  pip config set global.cache-dir "${tmpdir}" || echo "unable to set global.cache-dir"
+
+  # Download OS packages to tmpfs
+  if is_debuntu ; then
+    mount -t tmpfs tmpfs /var/cache/apt/archives
+  else
+    mount -t tmpfs tmpfs /var/cache/dnf
+  fi
+}
+
 function prepare_to_install(){
   nvsmi_works="0"
   readonly bdcfg="/usr/local/bin/bdconfig"
@@ -1343,38 +1375,8 @@ function prepare_to_install(){
 
   export DEBIAN_FRONTEND=noninteractive
 
-  local free_mem
   trap exit_handler EXIT
-  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
-  # Write to a ramdisk instead of churning the persistent disk
-  if [[ ${free_mem} -ge 10500000 ]]; then
-
-    # Services might use /tmp for temporary files - if we see errors,
-    # consider uncommenting the following command to stop them during
-    # install
-
-    # systemctl list-units | perl -n -e 'qx(systemctl stop $1) if /^.*? ((hadoop|knox|hive|mapred|yarn|hdfs)\S*).service/'
-    sudo mount -t tmpfs tmpfs /tmp
-
-    tmpdir="/mnt/shm"
-    mkdir -p "${tmpdir}"
-    mount -t tmpfs tmpfs "${tmpdir}"
-
-    # Clear pip cache
-    pip cache purge || echo "unable to purge pip cache"
-
-    # Download pip packages to tmpfs
-    pip config set global.cache-dir "${tmpdir}" || echo "unable to set global.cache-dir"
-
-    # Download OS packages to tmpfs
-    if is_debuntu ; then
-      mount -t tmpfs tmpfs /var/cache/apt/archives
-    else
-      mount -t tmpfs tmpfs /var/cache/dnf
-    fi
-  else
-    tmpdir=/tmp
-  fi
+  mount_ramdisk
   install_log="${tmpdir}/install.log"
 
   set_proxy
@@ -1385,7 +1387,7 @@ function prepare_to_install(){
     apt-get -y clean
     sleep 5s
     apt-get -y -qq autoremove
-    if is_debian12 ; then
+    if ge_debian12 ; then
     apt-mark unhold systemd libsystemd0 ; fi
   else
     dnf clean all

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -187,12 +187,14 @@ function is_cuda11() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "11" ]] ; )
 function le_cuda11() ( set +x ; version_le "${CUDA_VERSION%%.*}" "11" ; )
 function ge_cuda11() ( set +x ; version_ge "${CUDA_VERSION%%.*}" "11" ; )
 
-readonly DEFAULT_DRIVER="${DRIVER_FOR_CUDA[${CUDA_VERSION}]}"
+DEFAULT_DRIVER="${DRIVER_FOR_CUDA[${CUDA_VERSION}]}"
+if ( ge_ubuntu22 && version_le "${CUDA_VERSION}" "12.0" ) ; then
+                                         DEFAULT_DRIVER="560.28.03"  ; fi
+if ( is_debian11 || is_ubuntu20 ) ; then DEFAULT_DRIVER="560.28.03"  ; fi
+if ( is_rocky    && le_cuda11 )   ; then DEFAULT_DRIVER="525.147.05" ; fi
+if ( is_ubuntu20 && le_cuda11 )   ; then DEFAULT_DRIVER="535.183.06" ; fi
+if ( is_rocky9   && ge_cuda12 )   ; then DEFAULT_DRIVER="565.57.01"  ; fi
 DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
-if ( is_debian11 || is_ubuntu20 ) ; then DRIVER_VERSION="560.28.03"  ; fi
-if ( is_ubuntu20 && le_cuda11 )   ; then DRIVER_VERSION="535.183.06" ; fi
-if ( is_rocky && le_cuda11 )      ; then DRIVER_VERSION="525.147.05" ; fi #553.22.1
-if ( ge_ubuntu22 && version_le "${CUDA_VERSION}" "12.0" ) ; then DRIVER_VERSION="560.28.03"  ; fi
 
 readonly DRIVER_VERSION
 readonly DRIVER=${DRIVER_VERSION%%.*}

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -230,18 +230,27 @@ NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}
 readonly NCCL_REPO_URL
 readonly NCCL_REPO_KEY="${NVIDIA_BASE_DL_URL}/machine-learning/repos/${nccl_shortname}/x86_64/7fa2af80.pub" # 3bf863cc.pub
 
-if ge_cuda12 ; then
-  if (le_debian11 || le_ubuntu18)
-  then CUDA_DRIVER_VERSION="525.60.13"         ; CUDA_URL_VERSION="12.0.0"
-  else CUDA_DRIVER_VERSION="${DRIVER_VERSION}" ; CUDA_URL_VERSION="${CUDA_FULL_VERSION}" ; fi
+function set_cuda_runfile_url() {_
+  local RUNFILE_DRIVER_VERSION="${DRIVER_VERSION}"
+  local RUNFILE_CUDA_VERSION="${CUDA_FULL_VERSION}"
+  if ( ge_cuda12 && (le_debian11 || le_ubuntu18) ) ; then
+    RUNFILE_DRIVER_VERSION="525.60.13"
+    RUNFILE_CUDA_VERSION="12.0.0"
+  elif lt_cuda12
+    RUNFILE_DRIVER_VERSION="520.61.05"
+    RUNFILE_CUDA_VERSION="11.8.0"
+  fi
 
-  readonly DEFAULT_NVIDIA_CUDA_URL="${NVIDIA_BASE_DL_URL}/cuda/${CUDA_URL_VERSION}/local_installers/cuda_${CUDA_URL_VERSION}_${CUDA_DRIVER_VERSION}_linux.run"
-else
-  readonly DEFAULT_NVIDIA_CUDA_URL="https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
-fi
+  readonly RUNFILE_FILENAME="cuda_${RUNFILE_CUDA_VERSION}_${RUNFILE_DRIVER_VERSION}_linux.run"
+  CUDA_RELEASE_BASE_URL="${NVIDIA_BASE_DL_URL}/cuda/${RUNFILE_CUDA_VERSION}"
+  DEFAULT_NVIDIA_CUDA_URL="${CUDA_RELEASE_BASE_URL}/local_installers/${RUNFILE_FILENAME}"
+  readonly DEFAULT_NVIDIA_CUDA_URL
 
-NVIDIA_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_CUDA_URL}")
-readonly NVIDIA_CUDA_URL
+  NVIDIA_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_CUDA_URL}")
+  readonly NVIDIA_CUDA_URL
+}
+
+set_cuda_runfile_url
 
 # Parameter for NVIDIA-provided Rocky Linux GPU driver
 readonly NVIDIA_ROCKY_REPO_URL="${NVIDIA_REPO_URL}/cuda-${shortname}.repo"

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1094,8 +1094,8 @@ function install_dependencies() {
     local install_log="${tmpdir}/install.log"
     set +e
     eval "${dnf_cmd}" > "${install_log}" 2>&1
-    set -e
     local retval="$?"
+    set -e
 
     if [[ "${retval}" == "0" ]] ; then return ; fi
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -38,7 +38,6 @@ else _os_version="$(os_version)"; fi
 for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
   eval "function is_${os_id_val}() ( set +x ;  [[ \"$(os_id)\" == '${os_id_val}' ]] ; )"
 
-
   for osver in $(echo "${supported_os["${os_id_val}"]}") ; do
     eval "function is_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && [[ \"${_os_version}\" == \"${osver}\" ]] ; )"
     eval "function ge_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_ge \"${_os_version}\" \"${osver}\" ; )"
@@ -130,7 +129,7 @@ readonly ROLE
 # https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html
 # https://developer.nvidia.com/cuda-downloads
 readonly -A DRIVER_FOR_CUDA=(
-          [11.8]="525.147.05" [12.4]="550.54.14"  [12.6]="560.35.03"
+          [11.8]="525.147.05" [12.4]="550.54.14"  [12.6]="560.35.06"
 )
 # https://developer.nvidia.com/cudnn-downloads
 readonly -A CUDNN_FOR_CUDA=(
@@ -147,6 +146,10 @@ readonly -A CUDA_SUBVER=(
 RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'SPARK')
 readonly DEFAULT_CUDA_VERSION='12.4'
 CUDA_VERSION=$(get_metadata_attribute 'cuda-version' "${DEFAULT_CUDA_VERSION}")
+# CUDA 11 no longer supported on debian12 - 2024-11-22
+if ge_debian12 && version_le "${CUDA_VERSION%%.*}" "11" ; then
+  CUDA_VERSION="12.4"
+fi
 readonly CUDA_VERSION
 readonly CUDA_FULL_VERSION="${CUDA_SUBVER["${CUDA_VERSION}"]}"
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -192,6 +192,7 @@ DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}"
 if ( is_debian11 || is_ubuntu20 ) ; then DRIVER_VERSION="560.28.03"  ; fi
 if ( is_ubuntu20 && le_cuda11 )   ; then DRIVER_VERSION="535.183.06" ; fi
 if ( is_rocky && le_cuda11 )      ; then DRIVER_VERSION="525.147.05" ; fi #553.22.1
+if ( ge_ubuntu22 && version_le "${CUDA_VERSION}" "12.0" ) ; then DRIVER_VERSION="560.28.03"  ; fi
 
 readonly DRIVER_VERSION
 readonly DRIVER=${DRIVER_VERSION%%.*}

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -167,8 +167,8 @@ readonly -A CUDA_SUBVER=(
 RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'SPARK')
 readonly DEFAULT_CUDA_VERSION='12.4'
 CUDA_VERSION=$(get_metadata_attribute 'cuda-version' "${DEFAULT_CUDA_VERSION}")
-if ( ge_debian12 && version_le "${CUDA_VERSION%%.*}" "11" ) ; then
-  # CUDA 11 no longer supported on debian12 - 2024-11-22
+if ( ( ge_debian12 || ge_rocky9 ) && version_le "${CUDA_VERSION%%.*}" "11" ) ; then
+  # CUDA 11 no longer supported on debian12 - 2024-11-22, rocky9 - 2024-11-27
   CUDA_VERSION="${DEFAULT_CUDA_VERSION}"
 fi
 
@@ -180,18 +180,18 @@ readonly CUDA_VERSION
 readonly CUDA_FULL_VERSION="${CUDA_SUBVER["${CUDA_VERSION}"]}"
 
 function is_cuda12() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "12" ]] ; )
-function le_cuda12() ( set +x ; version_le "${CUDA_VERSION}" "12" ; )
-function ge_cuda12() ( set +x ; version_ge "${CUDA_VERSION}" "12" ; )
+function le_cuda12() ( set +x ; version_le "${CUDA_VERSION%%.*}" "12" ; )
+function ge_cuda12() ( set +x ; version_ge "${CUDA_VERSION%%.*}" "12" ; )
 
 function is_cuda11() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "11" ]] ; )
-function le_cuda11() ( set +x ; version_le "${CUDA_VERSION}" "11" ; )
-function ge_cuda11() ( set +x ; version_ge "${CUDA_VERSION}" "11" ; )
+function le_cuda11() ( set +x ; version_le "${CUDA_VERSION%%.*}" "11" ; )
+function ge_cuda11() ( set +x ; version_ge "${CUDA_VERSION%%.*}" "11" ; )
 
 readonly DEFAULT_DRIVER="${DRIVER_FOR_CUDA[${CUDA_VERSION}]}"
 DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
-if ( is_debian11 || ge_ubuntu20 )                                ; then DRIVER_VERSION="560.28.03"  ; fi
-if ( is_ubuntu20 && le_cuda11 )                                  ; then DRIVER_VERSION="535.183.06" ; fi
-if ( is_rocky8 && version_le "${DATAPROC_IMAGE_VERSION}" "2.0" ) ; then DRIVER_VERSION="525.147.05" ; fi #553.22.1
+if ( is_debian11 || is_ubuntu20 ) ; then DRIVER_VERSION="560.28.03"  ; fi
+if ( is_ubuntu20 && le_cuda11 )   ; then DRIVER_VERSION="535.183.06" ; fi
+if ( is_rocky && le_cuda11 )      ; then DRIVER_VERSION="525.147.05" ; fi #553.22.1
 
 readonly DRIVER_VERSION
 readonly DRIVER=${DRIVER_VERSION%%.*}

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -231,7 +231,7 @@ readonly NCCL_REPO_URL
 readonly NCCL_REPO_KEY="${NVIDIA_BASE_DL_URL}/machine-learning/repos/${nccl_shortname}/x86_64/7fa2af80.pub" # 3bf863cc.pub
 
 if ge_cuda12 ; then
-  if le_debian11 || le_ubuntu18
+  if (le_debian11 || le_ubuntu18)
   then CUDA_DRIVER_VERSION="525.60.13"         ; CUDA_URL_VERSION="12.0.0"
   else CUDA_DRIVER_VERSION="${DRIVER_VERSION}" ; CUDA_URL_VERSION="${CUDA_FULL_VERSION}" ; fi
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1092,7 +1092,9 @@ function install_dependencies() {
 
     local dnf_cmd="dnf -y -q install kernel-devel-${uname_r}"
     local install_log="${tmpdir}/install.log"
+    set +e
     eval "${dnf_cmd}" > "${install_log}" 2>&1
+    set -e
     local retval="$?"
 
     if [[ "${retval}" == "0" ]] ; then return ; fi

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -32,13 +32,17 @@ readonly -A supported_os=(
 )
 
 # dynamically define OS version test utility functions
+if [[ "$(os_id)" == "rocky" ]];
+then _os_version=$(os_version | sed -e 's/[^0-9]//g')
+else _os_version="$(os_version)"; fi
 for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
   eval "function is_${os_id_val}() ( set +x ;  [[ \"$(os_id)\" == '${os_id_val}' ]] ; )"
 
+
   for osver in $(echo "${supported_os["${os_id_val}"]}") ; do
-    eval "function is_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && [[ \"$(os_version)\" == \"${osver}\" ]] ; )"
-    eval "function ge_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_ge \"$(os_version)\" \"${osver}\" ; )"
-    eval "function le_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_le \"$(os_version)\" \"${osver}\" ; )"
+    eval "function is_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && [[ \"${_os_version}\" == \"${osver}\" ]] ; )"
+    eval "function ge_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_ge \"${_os_version}\" \"${osver}\" ; )"
+    eval "function le_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_le \"${_os_version}\" \"${osver}\" ; )"
   done
 done
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -805,7 +805,7 @@ function load_kernel_module() {
 
 # Install NVIDIA GPU driver provided by NVIDIA
 function install_nvidia_gpu_driver() {
-  if ge_debian12 && is_src_os ; then
+  if ( ge_debian12 && is_src_os ) ; then
     add_nonfree_components
     add_repo_nvidia_container_toolkit
     apt-get update -qq
@@ -819,7 +819,7 @@ function install_nvidia_gpu_driver() {
           libglvnd0 \
           libcuda1
     #clear_dkms_key
-  elif le_ubuntu18 || le_debian10 || (ge_debian12 && le_cuda11) ; then
+  elif ( le_ubuntu18 || le_debian10 || (ge_debian12 && le_cuda11) ) ; then
 
     install_nvidia_userspace_runfile
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -269,7 +269,7 @@ function set_cuda_runfile_url() {
       RUNFILE_DRIVER_VERSION="525.147.05"
       RUNFILE_CUDA_VERSION="12.0.0"
     fi
-  elif lt_cuda12 ; then
+  else
     RUNFILE_DRIVER_VERSION="520.61.05"
     RUNFILE_CUDA_VERSION="11.8.0"
   fi

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -35,15 +35,10 @@ readonly -A supported_os=(
 for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
   eval "function is_${os_id_val}() ( set +x ;  [[ \"$(os_id)\" == '${os_id_val}' ]] ; )"
 
-  # os_vercat depends on is_ubuntu and is_rocky so re-implement here
-  if   [[ "${os_id_val}" == "ubuntu" ]] ; then vernum=$(os_version | sed -e 's/[^0-9]//g')
-  elif [[ "${os_id_val}" == "rocky" ]]  ; then vernum=$(os_version | sed -e 's/[^0-9].*$//g')
-  else vernum="$(os_version)" ; fi
-
   for osver in $(echo "${supported_os["${os_id_val}"]}") ; do
-    eval "function is_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && [[ \"${vernum}}\" == ${osver}* ]] ; )"
-    eval "function ge_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_ge \"${vernum}\" ${osver} ; )"
-    eval "function le_${os_id_val}${osver}() ( set +x ; is_${os_id_val} && version_le \"${vernum}\" ${osver} ; )"
+    eval "function is_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && [[ \"$(os_version)\" == \"${osver}\" ]] ; )"
+    eval "function ge_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_ge \"$(os_version)\" \"${osver}\" ; )"
+    eval "function le_${os_id_val}${osver%%.*}() ( set +x ; is_${os_id_val} && version_le \"$(os_version)\" \"${osver}\" ; )"
   done
 done
 

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1251,7 +1251,7 @@ function exit_handler() {
     pip config unset global.cache-dir || echo "unable to unset global pip cache"
 
     # Clean up shared memory mounts
-    for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm /tmp ; do
+    for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm ; do
       if grep -q "^tmpfs ${shmdir}" /proc/mounts ; then
         rm -rf ${shmdir}/*
         sync

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -33,7 +33,7 @@ readonly -A supported_os=(
 
 # dynamically define OS version test utility functions
 if [[ "$(os_id)" == "rocky" ]];
-then _os_version=$(os_version | sed -e 's/[^0-9]//g')
+then _os_version=$(os_version | sed -e 's/[^0-9].*$//g')
 else _os_version="$(os_version)"; fi
 for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
   eval "function is_${os_id_val}() ( set +x ;  [[ \"$(os_id)\" == '${os_id_val}' ]] ; )"

--- a/gpu/manual-test-runner.sh
+++ b/gpu/manual-test-runner.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script sets up the gcloud environment and launches tests in a screen session
+#
+# To run the script, the following will bootstrap
+#
+# git clone git@github.com:LLC-Technologies-Collier/initialization-actions
+# git checkout gpu-20241121
+# cd initialization-actions
+# cp gpu/env.json.sample env.json
+# vi env.json
+# docker build -f gpu/Dockerfile -t gpu-init-actions-runner:latest .
+# time docker run -it gpu-init-actions-runner:latest gpu/manual-test-runner.sh
+#
+# The bazel run(s) happen in separate screen windows.
+#  To see a list of screen windows, press ^a "
+# Num Name
+#
+#   0 monitor
+#   1 2.0-debian10
+#   2 sh
+
+
+readonly timestamp="$(date +%F-%H-%M)"
+export BUILD_ID="$(uuidgen)"
+
+tmp_dir="/tmp/${BUILD_ID}"
+log_dir="${tmp_dir}/logs"
+mkdir -p "${log_dir}"
+
+IMAGE_VERSION="$1"
+if [[ -z "${IMAGE_VERSION}" ]] ; then
+       IMAGE_VERSION="$(jq -r .IMAGE_VERSION        env.json)" ; fi ; export IMAGE_VERSION
+export PROJECT_ID="$(jq    -r .PROJECT_ID           env.json)"
+export REGION="$(jq        -r .REGION               env.json)"
+export BUCKET="$(jq        -r .BUCKET               env.json)"
+
+gcs_log_dir="gs://${BUCKET}/${BUILD_ID}/logs"
+
+function exit_handler() {
+  RED='\\e[0;31m'
+  GREEN='\\e[0;32m'
+  NC='\\e[0m'
+  echo 'Cleaning up before exiting.'
+
+  # TODO: list clusters which match our BUILD_ID and clean them up
+  # TODO: remove any test related resources in the project
+
+  echo 'Uploading local logs to GCS bucket.'
+  gsutil -m rsync -r "${log_dir}/" "${gcs_log_dir}/"
+
+  if [[ -f "${tmp_dir}/tests_success" ]]; then
+    echo -e "${GREEN}Workflow succeeded${NC}, check logs at ${log_dir}/ or ${gcs_log_dir}/"
+    exit 0
+  else
+    echo -e "${RED}Workflow failed${NC}, check logs at ${log_dir}/ or ${gcs_log_dir}/"
+    exit 1
+  fi
+}
+
+trap exit_handler EXIT
+
+# screen session name
+session_name="manual-gpu-tests"
+
+gcloud config set project ${PROJECT_ID}
+gcloud config set dataproc/region ${REGION}
+gcloud auth login
+gcloud config set compute/region ${REGION}
+
+export INTERNAL_IP_SSH="true"
+
+# Run tests in screen session so we can monitor the container in another window
+screen -US "${session_name}" -c gpu/bazel.screenrc
+
+
+

--- a/gpu/run-bazel-tests.sh
+++ b/gpu/run-bazel-tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Run from root directory of initialization-actions checkout
+
+IMAGE="rapids-actions-image:$BUILD_ID"
+max_parallel_tests=10
+
+IMAGE_VERSION="$1"
+if [[ -z "${IMAGE_VERSION}" ]] ; then
+       IMAGE_VERSION="$(jq -r .IMAGE_VERSION        env.json)" ; fi ; export IMAGE_VERSION
+
+#declare -a TESTS_TO_RUN=('dask:test_dask' 'rapids:test_rapids')
+#declare -a TESTS_TO_RUN=('dask:test_dask')
+#declare -a TESTS_TO_RUN=('rapids:test_rapids')
+declare -a TESTS_TO_RUN=('gpu:test_gpu')
+
+time bazel test \
+  --jobs="${max_parallel_tests}" \
+  --local_test_jobs="${max_parallel_tests}" \
+  --flaky_test_attempts=3 \
+  --action_env="INTERNAL_IP_SSH=true" \
+  --test_output="errors" \
+  --test_arg="--image_version=${IMAGE_VERSION}" \
+  "${TESTS_TO_RUN[@]}"

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -128,6 +128,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
+    if pkg_resources.parse_version(cuda_version) == pkg_resources.parse_version("12.0") \
+    and ( self.getImageOs() == 'debian' and self.getImageVersion() >= pkg_resources.parse_version("2.2") ):
+      self.skipTest("CUDA == 12.0 not supported on debian 12")
+
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
           ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
@@ -166,6 +170,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
+
+    if pkg_resources.parse_version(cuda_version) == pkg_resources.parse_version("12.0") \
+    and ( self.getImageOs() == 'debian' and self.getImageVersion() >= pkg_resources.parse_version("2.2") ):
+      self.skipTest("CUDA == 12.0 not supported on debian 12")
 
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
@@ -244,6 +252,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
+
+    if pkg_resources.parse_version(cuda_version) == pkg_resources.parse_version("12.0") \
+    and ( self.getImageOs() == 'debian' and self.getImageVersion() >= pkg_resources.parse_version("2.2") ):
+      self.skipTest("CUDA == 12.0 not supported on debian 12")
 
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -49,8 +49,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       +   "spark.executor.resource.gpu.amount=1," \
       +   "spark.executor.cores=6,"               \
       +   "spark.executor.memory=4G,"             \
-      +   "spark.task.resource.gpu.amount=0.166," \
-      +   "spark.task.cpus=1,"                    \
+      +   "spark.task.resource.gpu.amount=0.333," \
+      +   "spark.task.cpus=2,"                    \
       +   "spark.yarn.unmanagedAM.enabled=false"
     )
 

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -45,14 +45,18 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       "spark",
       "--jars=file:///usr/lib/spark/examples/jars/spark-examples.jar " \
       + "--class=org.apache.spark.examples.ml.JavaIndexToStringExample " \
-      + "--properties=" \
+      + "--properties="                           \
       +   "spark.executor.resource.gpu.amount=1," \
-      +   "spark.task.resource.gpu.amount=0.01"
+      +   "spark.executor.cores=6"                \
+      +   "spark.executor.memory=4G"              \
+      +   "spark.task.resource.gpu.amount=0.166"  \
+      +   "spark.task.cpus=1"                     \
+      +   "spark.yarn.unmanagedAM.enabled=false"
     )
 
   @parameterized.parameters(
-      ("SINGLE", ["m"], GPU_T4, None, None),
-      ("STANDARD", ["m"], GPU_T4, None, None),
+      ("SINGLE",   ["m"], GPU_T4, None, None),
+#      ("STANDARD", ["m"], GPU_T4, None, None),
       ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, "NVIDIA"),
   )
   def test_install_gpu_default_agent(self, configuration, machine_suffixes,
@@ -80,7 +84,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         self.verify_pyspark(machine_name)
 
   @parameterized.parameters(
-      ("SINGLE", ["m"], GPU_T4, None, None),
+#      ("SINGLE", ["m"], GPU_T4, None, None),
   )
   def test_install_gpu_without_agent(self, configuration, machine_suffixes,
                                      master_accelerator, worker_accelerator,
@@ -106,8 +110,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
       ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, None),
-      ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "NVIDIA"),
-      ("STANDARD", ["m"], GPU_T4, None, "NVIDIA"),
+#      ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "NVIDIA"),
+#      ("STANDARD", ["m"], GPU_T4, None, "NVIDIA"),
   )
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
@@ -135,10 +139,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                                     machine_suffix))
 
   @parameterized.parameters(
-      ("SINGLE",   ["m"],               GPU_T4, None,   "12.0"),
-      ("STANDARD", ["m"],               GPU_T4, None,   "11.8"),
+#       ("SINGLE", ["m"],               GPU_T4, None,   "12.0"),
+        ("SINGLE", ["m"],               GPU_T4, None,   "11.8"),
       ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, "12.4"),
-      ("STANDARD", ["w-0", "w-1"],      None,   GPU_T4, "11.8"),
+#     ("STANDARD", ["w-0", "w-1"],      None,   GPU_T4, "11.8"),
   )
   def test_install_gpu_cuda_nvidia(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
@@ -177,7 +181,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
       ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "11.8"),
-      ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "12.0"),
+#      ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "12.0"),
       ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "12.4"),
   )
   def test_install_gpu_with_mig(self, configuration, machine_suffixes,
@@ -232,7 +236,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() <= pkg_resources.parse_version("2.1") \
     and configuration == 'SINGLE':
-      self.skipTest("2.1-rocky8 and 2.0-rocky8 single instance tests fail with errors about nodes_include being empty")
+      self.skipTest("2.1-rocky8 and 2.0-rocky8 single instance tests are known to fail with errors about nodes_include being empty")
 
     metadata = None
     if driver_provider is not None:
@@ -252,10 +256,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
     ("SINGLE", ["m"], GPU_T4, None, "11.8"),
-    ("STANDARD", ["m"], GPU_T4, None, "12.0"),
+#    ("STANDARD", ["m"], GPU_T4, None, "12.0"),
     ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, "12.4"),
-    ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "11.8"),
-    ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "12.0"),
+#    ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "11.8"),
+#    ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "12.0"),
   )
   def test_install_gpu_cuda_nvidia_with_spark_job(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -47,10 +47,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       + "--class=org.apache.spark.examples.ml.JavaIndexToStringExample " \
       + "--properties="                           \
       +   "spark.executor.resource.gpu.amount=1," \
-      +   "spark.executor.cores=6"                \
-      +   "spark.executor.memory=4G"              \
-      +   "spark.task.resource.gpu.amount=0.166"  \
-      +   "spark.task.cpus=1"                     \
+      +   "spark.executor.cores=6,"               \
+      +   "spark.executor.memory=4G,"             \
+      +   "spark.task.resource.gpu.amount=0.166," \
+      +   "spark.task.cpus=1,"                    \
       +   "spark.yarn.unmanagedAM.enabled=false"
     )
 

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -111,7 +111,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                                     machine_suffix))
 
   @parameterized.parameters(
-      ("SINGLE",   ["m"],               GPU_T4, None,   "12.4"),
+      ("SINGLE",   ["m"],               GPU_T4, None,   "12.0"),
       ("STANDARD", ["m"],               GPU_T4, None,   "11.8"),
       ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, "12.4"),
       ("STANDARD", ["w-0", "w-1"],      None,   GPU_T4, "11.8"),
@@ -120,10 +120,13 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if self.getImageOs() == "debian" \
-    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
-    and cuda_version < "12":
-      self.skipTest("CUDA < 12 not supported on debian12")
+    if self.getImageVersion() <= pkg_resources.parse_version("2.0") \
+    and pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+      self.skipTest("CUDA > 12.0 not supported on Dataproc <= 2.0")
+
+    if self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0"):
+      self.skipTest("CUDA < 12 not supported on  Dataproc >= 2.2")
 
     metadata = "gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(
@@ -150,8 +153,13 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
 
-    if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
-      self.skipTest("CUDA 11 not supported on debian12")
+    if self.getImageVersion() <= pkg_resources.parse_version("2.0") \
+    and pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+      self.skipTest("CUDA > 12.0 not supported on Dataproc <= 2.0")
+
+    if self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0"):
+      self.skipTest("CUDA < 12 not supported on  Dataproc >= 2.2")
 
     metadata = "gpu-driver-provider={},cuda-version={}".format(driver_provider, cuda_version)
 
@@ -207,25 +215,22 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   @parameterized.parameters(
     ("SINGLE", ["m"], GPU_T4, None, "11.8"),
-    ("STANDARD", ["m"], GPU_T4, None, "11.8"),
-    ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, "11.8"),
+    ("STANDARD", ["m"], GPU_T4, None, "12.0"),
+    ("STANDARD", ["m", "w-0", "w-1"], GPU_T4, GPU_T4, "12.4"),
     ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "11.8"),
-    ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "12.4"),
+    ("STANDARD", ["w-0", "w-1"], None, GPU_T4, "12.0"),
   )
   def test_install_gpu_cuda_nvidia_with_spark_job(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if self.getImageOs() == "debian" \
-    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
-    and cuda_version < "12":
-      self.skipTest("CUDA < 12 not supported on debian12")
+    if self.getImageVersion() <= pkg_resources.parse_version("2.0") \
+    and pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+      self.skipTest("CUDA > 12.0 not supported on Dataproc <= 2.0")
 
-    # 24/11/25 19:58:06 ERROR org.apache.spark.SparkContext: Error initializing SparkContext.
-    # org.apache.spark.SparkException: No executor resource configs were not specified for the following task configs: gpu
-    if self.getImageVersion() <= pkg_resources.parse_version("2.0"):
-      self.skipTest("Dataproc 2.0 has problems with CUDA < 12 not supported on debian12")
-
+    if self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0"):
+      self.skipTest("CUDA < 12 not supported on  Dataproc >= 2.2")
 
     metadata = "install-gpu-agent=true,gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -49,7 +49,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-2",
+        machine_type="n1-standard-16",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -72,7 +72,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-2",
+        machine_type="n1-standard-16",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -97,7 +97,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-2",
+        machine_type="n1-standard-16",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -124,7 +124,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-2",
+        machine_type="n1-standard-16",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -178,7 +178,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         configuration,
         self.INIT_ACTIONS,
         metadata=metadata,
-        machine_type="n1-standard-2",
+        machine_type="n1-standard-16",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         boot_disk_size="50GB",
@@ -214,7 +214,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
       configuration,
       self.INIT_ACTIONS,
-      machine_type="n1-standard-2",
+      machine_type="n1-standard-16",
       master_accelerator=master_accelerator,
       worker_accelerator=worker_accelerator,
       metadata=metadata,

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -46,8 +46,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       "--jars=file:///usr/lib/spark/examples/jars/spark-examples.jar " \
       + "--class=org.apache.spark.examples.ml.JavaIndexToStringExample " \
       + "--properties=" \
-      +   "spark:spark.executor.resource.gpu.amount=1,"
-      +   "spark:spark.task.resource.gpu.amount=0.01"
+      +   "spark.executor.resource.gpu.amount=1," \
+      +   "spark.task.resource.gpu.amount=0.01"
     )
 
   @parameterized.parameters(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -145,6 +145,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_with_mig(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
                                   driver_provider, cuda_version):
+
     self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
 
     if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
@@ -174,7 +175,6 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   )
   def test_gpu_allocation(self, configuration, master_accelerator,
                           worker_accelerator, driver_provider):
-    self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
 
     metadata = None
     if driver_provider is not None:
@@ -192,14 +192,13 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     get_gpu_resources_script="/usr/lib/spark/scripts/gpu/getGpusResources.sh"
     self.assert_dataproc_job(
-        self.getClusterName(),
-        "spark",
+      self.getClusterName(),
       "spark",
       "--jars=file:///usr/lib/spark/examples/jars/spark-examples.jar " \
       + "--class=org.apache.spark.examples.ml.JavaIndexToStringExample " \
       + "--properties=" \
       +   "spark.driver.resource.gpu.amount=1," \
-      +   "spark.driver.resource.gpu.discoveryScript=" + get_gpu_resources_script \
+      +   "spark.driver.resource.gpu.discoveryScript=" + get_gpu_resources_script + "," \
       +   "spark.executor.resource.gpu.amount=1," \
       +   "spark.executor.resource.gpu.discoveryScript=" + get_gpu_resources_script
     )
@@ -214,7 +213,6 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_cuda_nvidia_with_spark_job(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
-    self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
 
     if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("CUDA 11 not supported on debian12")
@@ -244,7 +242,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       + "--class=org.apache.spark.examples.ml.JavaIndexToStringExample " \
       + "--properties=" \
       +   "spark.driver.resource.gpu.amount=1," \
-      +   "spark.driver.resource.gpu.discoveryScript=" + get_gpu_resources_script \
+      +   "spark.driver.resource.gpu.discoveryScript=" + get_gpu_resources_script + "," \
       +   "spark.executor.resource.gpu.amount=1," \
       +   "spark.executor.resource.gpu.discoveryScript=" + get_gpu_resources_script
     )

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -120,14 +120,14 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
           ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
       self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
     if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
     and self.getImageOs() == 'debian' \
-    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("CUDA < 12 not supported on Debian >= 12")
 
     metadata = "gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
@@ -163,7 +163,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
     and self.getImageOs() == 'debian' \
-    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("CUDA < 12 not supported on Debian >= 12")
 
     metadata = "gpu-driver-provider={},cuda-version={}".format(driver_provider, cuda_version)
@@ -229,14 +229,14 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
           ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
       self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
     if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
     and self.getImageOs() == 'debian' \
-    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("CUDA < 12 not supported on Debian >= 12")
 
     metadata = "install-gpu-agent=true,gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -120,6 +120,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
+    if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("CUDA 11 not supported on debian12")
+
     metadata = "gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(
         configuration,
@@ -143,6 +146,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                   master_accelerator, worker_accelerator,
                                   driver_provider, cuda_version):
     self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
+
+    if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("CUDA 11 not supported on debian12")
 
     metadata = "gpu-driver-provider={},cuda-version={}".format(driver_provider, cuda_version)
 
@@ -209,6 +215,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
     self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
+
+    if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("CUDA 11 not supported on debian12")
 
     metadata = "install-gpu-agent=true,gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -49,7 +49,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-16",
+        machine_type="n1-highmem-8",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -72,7 +72,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-16",
+        machine_type="n1-highmem-8",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -97,7 +97,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-16",
+        machine_type="n1-highmem-8",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -124,7 +124,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
         configuration,
         self.INIT_ACTIONS,
-        machine_type="n1-standard-16",
+        machine_type="n1-highmem-8",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         metadata=metadata,
@@ -178,7 +178,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         configuration,
         self.INIT_ACTIONS,
         metadata=metadata,
-        machine_type="n1-standard-16",
+        machine_type="n1-highmem-8",
         master_accelerator=master_accelerator,
         worker_accelerator=worker_accelerator,
         boot_disk_size="50GB",
@@ -214,7 +214,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     self.createCluster(
       configuration,
       self.INIT_ACTIONS,
-      machine_type="n1-standard-16",
+      machine_type="n1-highmem-8",
       master_accelerator=master_accelerator,
       worker_accelerator=worker_accelerator,
       metadata=metadata,

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -84,11 +84,14 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
         self.verify_pyspark(machine_name)
 
   @parameterized.parameters(
-#      ("SINGLE", ["m"], GPU_T4, None, None),
+      ("SINGLE", ["m"], GPU_T4, None, None),
   )
   def test_install_gpu_without_agent(self, configuration, machine_suffixes,
                                      master_accelerator, worker_accelerator,
                                      driver_provider):
+
+    self.skipTest("No need to regularly test not installing the agent")
+
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; base dataproc image out of date")
 

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -214,8 +214,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
-      self.skipTest("CUDA 11 not supported on debian12")
+    if self.getImageOs() == "debian" \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and cuda_version < "12":
+      self.skipTest("CUDA < 12 not supported on debian12")
 
     metadata = "install-gpu-agent=true,gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -17,6 +17,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   def verify_instance(self, name):
     self.assert_instance_command(name, "nvidia-smi", 1)
+    self.assert_instance_command(name, "echo 'from pyspark.sql import SparkSession ; SparkSession.builder.appName(\'HelloWorld\').getOrCreate()' | pyspark", 1)
 
   def verify_mig_instance(self, name):
     self.assert_instance_command(name,

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -120,8 +120,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if self.getImageOs() == "debian" and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
-      self.skipTest("CUDA 11 not supported on debian12")
+    if self.getImageOs() == "debian" \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+    and cuda_version < "12":
+      self.skipTest("CUDA < 12 not supported on debian12")
 
     metadata = "gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -42,6 +42,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_default_agent(self, configuration, machine_suffixes,
                                      master_accelerator, worker_accelerator,
                                      driver_provider):
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
     metadata = None
     if driver_provider is not None:
@@ -65,6 +67,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_without_agent(self, configuration, machine_suffixes,
                                      master_accelerator, worker_accelerator,
                                      driver_provider):
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
     metadata = "install-gpu-agent=false"
     if driver_provider is not None:
@@ -90,6 +94,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
                                   driver_provider):
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
     metadata = "install-gpu-agent=true"
     if driver_provider is not None:
@@ -119,6 +125,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_cuda_nvidia(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
@@ -156,6 +164,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
 
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
+
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
           ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
@@ -190,6 +201,8 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   )
   def test_gpu_allocation(self, configuration, master_accelerator,
                           worker_accelerator, driver_provider):
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
     metadata = None
     if driver_provider is not None:
@@ -228,6 +241,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   def test_install_gpu_cuda_nvidia_with_spark_job(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
+
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -13,7 +13,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
   GPU_T4   = "type=nvidia-tesla-t4"
   GPU_V100 = "type=nvidia-tesla-v100" # not available in us-central1-a
   GPU_A100 = "type=nvidia-tesla-a100"
-  GPU_H100 = "type=nvidia-h100-80gb"
+  GPU_H100 = "type=nvidia-h100-80gb,count=8"
 
   def verify_instance(self, name):
     self.assert_instance_command(name, "nvidia-smi", 1)
@@ -120,13 +120,15 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if self.getImageVersion() <= pkg_resources.parse_version("2.0") \
-    and pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
-      self.skipTest("CUDA > 12.0 not supported on Dataproc <= 2.0")
+    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+    and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
+          ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
+      self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
-    if self.getImageVersion() >= pkg_resources.parse_version("2.2") \
-    and pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0"):
-      self.skipTest("CUDA < 12 not supported on  Dataproc >= 2.2")
+    if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
+    and self.getImageOs() == 'debian' \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+      self.skipTest("CUDA < 12 not supported on Debian >= 12")
 
     metadata = "gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(
@@ -144,8 +146,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       self.verify_instance_nvcc(machine_name, cuda_version)
 
   @parameterized.parameters(
-      ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "12.4"),
       ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "11.8"),
+      ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "12.0"),
+      ("STANDARD", ["m"], GPU_H100, GPU_A100, "NVIDIA", "12.4"),
   )
   def test_install_gpu_with_mig(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
@@ -153,13 +156,15 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     self.skipTest("Test is known to fail.  Skipping so that we can exercise others")
 
-    if self.getImageVersion() <= pkg_resources.parse_version("2.0") \
-    and pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
-      self.skipTest("CUDA > 12.0 not supported on Dataproc <= 2.0")
+    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0") \
+    and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
+          ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
+      self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
-    if self.getImageVersion() >= pkg_resources.parse_version("2.2") \
-    and pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0"):
-      self.skipTest("CUDA < 12 not supported on  Dataproc >= 2.2")
+    if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
+    and self.getImageOs() == 'debian' \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+      self.skipTest("CUDA < 12 not supported on Debian >= 12")
 
     metadata = "gpu-driver-provider={},cuda-version={}".format(driver_provider, cuda_version)
 
@@ -224,13 +229,15 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
 
-    if self.getImageVersion() <= pkg_resources.parse_version("2.0") \
-    and pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
-      self.skipTest("CUDA > 12.0 not supported on Dataproc <= 2.0")
+    if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.0"):
+    and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \
+          ( self.getImageOs() == 'debian' and self.getImageVersion() <= pkg_resources.parse_version("2.1") ) ):
+      self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
-    if self.getImageVersion() >= pkg_resources.parse_version("2.2") \
-    and pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0"):
-      self.skipTest("CUDA < 12 not supported on  Dataproc >= 2.2")
+    if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
+    and self.getImageOs() == 'debian' \
+    and self.getImageVersion() >= pkg_resources.parse_version("2.2") \
+      self.skipTest("CUDA < 12 not supported on Debian >= 12")
 
     metadata = "install-gpu-agent=true,gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -212,6 +212,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.0") \
+    and configuration == 'SINGLE':
+      self.skipTest("2.0-rocky8 single instance tests fail")
+
     metadata = None
     if driver_provider is not None:
       metadata = "gpu-driver-provider={}".format(driver_provider)
@@ -252,6 +256,10 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
+
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.0") \
+    and configuration == 'SINGLE':
+      self.skipTest("2.0-rocky8 single instance tests fail")
 
     if pkg_resources.parse_version(cuda_version) == pkg_resources.parse_version("12.0") \
     and ( self.getImageOs() == 'debian' and self.getImageVersion() >= pkg_resources.parse_version("2.2") ):

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -1,4 +1,5 @@
 import pkg_resources
+import time
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -17,6 +18,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
 
   def verify_instance(self, name):
     # Verify that nvidia-smi works
+    time.sleep(3) # Many failed nvidia-smi attempts have been caused by impatience
     self.assert_instance_command(name, "nvidia-smi", 1)
 
   def verify_pyspark(self, name):
@@ -80,7 +82,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     for machine_suffix in machine_suffixes:
       machine_name="{}-{}".format(self.getClusterName(),machine_suffix)
       self.verify_instance(machine_name)
-      if ( self.getImageOs() != 'rocky' ) or ( configuration != 'SINGLE' ) or ( configure == 'SINGLE' and self.getImageOs() == 'rocky' and self.getImageVersion() > pkg_resources.parse_version("2.1") ):
+      if ( self.getImageOs() != 'rocky' ) or ( configuration != 'SINGLE' ) or ( configuration == 'SINGLE' and self.getImageOs() == 'rocky' and self.getImageVersion() > pkg_resources.parse_version("2.1") ):
         self.verify_pyspark(machine_name)
 
   @parameterized.parameters(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -126,9 +126,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
     if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
-    and self.getImageOs() == 'debian' \
+    and ( self.getImageOs() == 'debian' or self.getImageOs() == 'rocky' ) \
     and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
-      self.skipTest("CUDA < 12 not supported on Debian >= 12")
+      self.skipTest("CUDA < 12 not supported on Debian >= 12, Rocky >= 9")
 
     metadata = "gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(
@@ -162,9 +162,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
     if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
-    and self.getImageOs() == 'debian' \
+    and ( self.getImageOs() == 'debian' or self.getImageOs() == 'rocky' ) \
     and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
-      self.skipTest("CUDA < 12 not supported on Debian >= 12")
+      self.skipTest("CUDA < 12 not supported on Debian >= 12, Rocky >= 9")
 
     metadata = "gpu-driver-provider={},cuda-version={}".format(driver_provider, cuda_version)
 
@@ -235,9 +235,9 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
       self.skipTest("CUDA > 12.0 not supported on older debian/ubuntu releases")
 
     if pkg_resources.parse_version(cuda_version) < pkg_resources.parse_version("12.0") \
-    and self.getImageOs() == 'debian' \
+    and ( self.getImageOs() == 'debian' or self.getImageOs() == 'rocky' ) \
     and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
-      self.skipTest("CUDA < 12 not supported on Debian >= 12")
+      self.skipTest("CUDA < 12 not supported on Debian >= 12, Rocky >= 9")
 
     metadata = "install-gpu-agent=true,gpu-driver-provider=NVIDIA,cuda-version={}".format(cuda_version)
     self.createCluster(

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -212,7 +212,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
-    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.0") \
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() <= pkg_resources.parse_version("2.0") \
     and configuration == 'SINGLE':
       self.skipTest("2.0-rocky8 single instance tests fail")
 
@@ -257,7 +257,7 @@ class NvidiaGpuDriverTestCase(DataprocTestCase):
     if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
       self.skipTest("GPU drivers are currently FTBFS on Rocky 9 ; image out of date")
 
-    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() >= pkg_resources.parse_version("2.0") \
+    if ( self.getImageOs() == 'rocky' ) and self.getImageVersion() <= pkg_resources.parse_version("2.0") \
     and configuration == 'SINGLE':
       self.skipTest("2.0-rocky8 single instance tests fail")
 


### PR DESCRIPTION
* Capturing disk usage statistics to reduce excessive disk space
* created exit handler to clean up environment on completion or failure
* created prepare function to prepare for the installation
* when sufficient memory is available, configure a ramdisk
* reduce noise by turning off -x in utility functions
* added descriptive comments before the obscurely coded compare_versions_lte and compare_versions_lt functions
* removed some intermediate driver versions
* added cuda url for 12.6
* execute_with_retries now logs on failure, captures runtime and cleans before installing on debian
* saving OS installation and NV .run files and their temp files to ramdisk
* piping source .xz file directly xz instead of saving to disk first
* new utility function "is_debuntu" checks for the frequently used conditon of whether the running OS is either debian or ubuntu
* added support for specifying an http proxy (thank you प्रकाश)
* moving load of kernel module to later in the code and exercising modprobe of all modules to avoid regression
* fixed problem with attempting to fetch from incorrect vault directory when rocky kernel package is not found in primary repo
* using correct cran-r signing key for ubuntu18
* corrected file check condition for /etc/apt/trusted.gpg