### PR TITLE
Improve documentation for manual testing

### DIFF
--- a/gpu/manual-test-runner.sh
+++ b/gpu/manual-test-runner.sh
@@ -4,21 +4,23 @@
 #
 # To run the script, the following will bootstrap
 #
-# git clone git@github.com:LLC-Technologies-Collier/initialization-actions
-# git checkout gpu-20241121
+# git clone git@github.com:GoogleCloudDataproc/initialization-actions
+# git checkout 2024-11
 # cd initialization-actions
 # cp gpu/env.json.sample env.json
 # vi env.json
 # docker build -f gpu/Dockerfile -t gpu-init-actions-runner:latest .
 # time docker run -it gpu-init-actions-runner:latest gpu/manual-test-runner.sh
 #
-# The bazel run(s) happen in separate screen windows.
-#  To see a list of screen windows, press ^a "
+# The bazel run(s) happen in separate GNU screen[1] windows.
+#  To create a new screen window, press ^a c (Ctrl-a c)
+#  To see a list of screen windows, press ^a " (Ctrl-a ")
 # Num Name
 #
-#   0 monitor
+#   0 sh
 #   1 2.0-debian10
-#   2 sh
+#
+# [1] https://www.gnu.org/software/screen/
 
 
 readonly timestamp="$(date +%F-%H-%M)"


### PR DESCRIPTION
Now using the upstream URI instead of the staging value Now referencing the 2024-11 branch instead of the work-in-progress branch of the staging repository.

Please cowboy approve this change since it is documentation only and will not change test results.