### PR TITLE
[bazel] updated to allow pinning of bazel version

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -9,16 +9,24 @@ COPY --chown=ia-tests:ia-tests . /init-actions
 
 # Install Bazel:
 # https://docs.bazel.build/versions/master/install-ubuntu.html
-ENV bazel_kr_path=/usr/share/keyrings/bazel-keyring.gpg
+ENV bazel_kr_path=/usr/share/keyrings/bazel-keyring.gpg \
+    bazel_version=7.4.0 \
+    bazel_repo_data="http://storage.googleapis.com/bazel-apt stable jdk1.8" \
+    bazel_repo_file="/etc/apt/sources.list.d/bazel.list"
+    DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y -qq curl >/dev/null 2>&1 && \
     apt-get clean
-RUN /usr/bin/curl https://bazel.build/bazel-release.pub.gpg | \
-    gpg --dearmor -o "${bazel_kr_path}"
-RUN echo "deb [arch=amd64 signed-by=${bazel_kr_path}] http://storage.googleapis.com/bazel-apt stable jdk1.8" | \
-    dd of=/etc/apt/sources.list.d/bazel.list status=none && \
+RUN /usr/bin/curl -s https://bazel.build/bazel-release.pub.gpg | \
+    gpg --import --no-default-keyring --keyring "${bazel_kr_path}" && \
+    echo "deb [arch=amd64 signed-by=${bazel_kr_path}] ${bazel_repo_data}" | \
+    dd of="${bazel_repo_file}" status=none && \
     apt-get update -qq
-RUN apt-get autoremove -y -qq && \
-    apt-get install -y -qq openjdk-8-jdk python3-setuptools bazel >/dev/null 2>&1 && \
+RUN apt-get autoremove -y -qq > /dev/null 2>&1 && \
+    apt-get install -y -qq default-jdk python3-setuptools bazel-${bazel_version} > /dev/null 2>&1 && \
     apt-get clean
+
+# Set bazel-${bazel_version} as the default bazel alternative in this container
+RUN update-alternatives --install /usr/bin/bazel bazel /usr/bin/bazel-${bazel_version} 1 && \
+    update-alternatives                    --set bazel /usr/bin/bazel-${bazel_version}
 
 USER ia-tests

--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=ia-tests:ia-tests . /init-actions
 ENV bazel_kr_path=/usr/share/keyrings/bazel-keyring.gpg \
     bazel_version=7.4.0 \
     bazel_repo_data="http://storage.googleapis.com/bazel-apt stable jdk1.8" \
-    bazel_repo_file="/etc/apt/sources.list.d/bazel.list"
+    bazel_repo_file="/etc/apt/sources.list.d/bazel.list" \
     DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y -qq curl >/dev/null 2>&1 && \
     apt-get clean


### PR DESCRIPTION
* now using environment variables more
* using gpg --import instead of gpg --dearmor
* must set default bazel using update-alternatives or bazel is not in PATH, only bazel-7.4.0
  * Although this could possibly be solved by replacing all calls to bazel in our code with bazel-7.4.0 this does not hold true for others' code which does not know to change the abi