### PR TITLE
[hive-lineage] Update hive-lineage.sh

### DIFF
--- a/hive-lineage/hive-lineage.sh
+++ b/hive-lineage/hive-lineage.sh
@@ -34,7 +34,8 @@ function set_hive_lineage_conf() {
     ["hive.exec.post.hooks"]="$HIVE_OL_HOOK"
     ["hive.exec.failure.hooks"]="$HIVE_OL_HOOK"
     ["hive.openlineage.transport.type"]="gcplineage"
-    ["hive.conf.validation"]="false" # to allow custom properties, like hive.openlineage.namespace
+    ["hive.security.authorization.sqlstd.confwhitelist.append"]="tez.application.tags|hive.openlineage.*"
+    ["hive.conf.validation"]="false"
   )
   echo "Setting hive conf to enable lineage"
   for key in "${!properties[@]}"; do

--- a/hive-lineage/test_hive_lineage.py
+++ b/hive-lineage/test_hive_lineage.py
@@ -9,9 +9,13 @@ class HiveLineageTestCase(DataprocTestCase):
   TEST_SCRIPT_FILE = "hive-lineage/hivetest.hive"
 
   def __submit_hive_job(self, cluster_name):
-    self.assert_dataproc_job(
-        cluster_name, 'hive', '--file={}/{}'.format(self.INIT_ACTIONS_REPO,
-                                                    self.TEST_SCRIPT_FILE))
+    properties = "hive.openlineage.namespace=init-actions-test"
+    self.assert_dataproc_job(cluster_name, 'hive',
+                             '--file={}/{} --properties={}'.format(
+                                 self.INIT_ACTIONS_REPO,
+                                 self.TEST_SCRIPT_FILE,
+                                 properties))
+
   def verify_cluster(self, name):
     self.__submit_hive_job(name)
 

--- a/hive-lineage/test_hive_lineage.py
+++ b/hive-lineage/test_hive_lineage.py
@@ -18,6 +18,7 @@ class HiveLineageTestCase(DataprocTestCase):
   @parameterized.parameters(
       'STANDARD',
       'HA',
+      'KERBEROS',
   )
   def test_hive_job_success(self, configuration):
     self.createCluster(configuration,


### PR DESCRIPTION
This change appends hive confwhitelist in hive-lineage.sh to allow users to set custom hive openlineage properties at runtime.

In the previous version of the script, workloads were failing for kerberos-enabled clusters when setting `hive.openlineage.namespace` in job properties. This change fixes the issue.