### PR TITLE
Adding support for 2.3

### DIFF
--- a/bigtable/bigtable.sh
+++ b/bigtable/bigtable.sh
@@ -230,7 +230,7 @@ function install_hbase() {
       fi
       ;;
 
-    "2.0" | "2.1" | "2.2" )
+    "2.0" | "2.1" | "2.2" | "2.3" )
 
       # get hbase tar from official site
       # Variants:

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -80,7 +80,7 @@ case "${DATAPROC_IMAGE_VERSION}" in
     curator_version="2.13.0"
     curator_src="/usr/lib/hadoop/lib"
     ;;
-  "2.1" | "2.2")
+  "2.1" | "2.2" | "2.3" )
     curator_version="2.13.0"
     curator_src="/usr/lib/spark/jars"
     ;;


### PR DESCRIPTION
Provide support to enable the init action to pass for 2.3 dataproc image version