### PR TITLE
[gpu] exercise tests against internal suite

### DIFF
--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -990,9 +990,9 @@ function add_repo_cuda() {
       echo "deb [signed-by=${kr_path}] https://developer.download.nvidia.com/compute/cuda/repos/${shortname}/x86_64/ /" \
       | sudo tee "${sources_list_path}"
 
-      for keyid in "0xae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80" "0xeb693b3035cd5710e231e123a4b469963bf863cc" ; do
-        gpg --keyserver keyserver.ubuntu.com --no-default-keyring --keyring "${kr_path}" --recv-keys "${keyid}"
-      done
+      gpg --keyserver keyserver.ubuntu.com \
+        --no-default-keyring --keyring "${kr_path}" \
+        --recv-keys "0xae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80" "0xeb693b3035cd5710e231e123a4b469963bf863cc"
     else
       install_cuda_keyring_pkg # 11.7+, 12.0+
     fi

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1755,13 +1755,14 @@ function prepare_gpu_env(){
       "1BB3" ) gpu_type="nvidia-tesla-p4"        ;;
       "1DB1" ) gpu_type="nvidia-tesla-v100"      ;;
       "1EB8" ) gpu_type="nvidia-tesla-t4"        ;;
-      "20B2" | \
-      "20B5" | \
-      "20F3" | \
+      "20B2" ) gpu_type="nvidia-tesla-a100-80gb" ;;
+      "20B5" ) gpu_type="nvidia-tesla-a100-80gb" ;;
+      "20F3" ) gpu_type="nvidia-tesla-a100-80gb" ;;
       "20F5" ) gpu_type="nvidia-tesla-a100-80gb" ;;
-      "20*"  ) gpu_type="nvidia-tesla-a100"      ;;
-      "23*"  ) gpu_type="nvidia-h100"            ;; # NB: install does not begin with legacy image 2.0.68-debian10/cuda11.1
+      "20"*  ) gpu_type="nvidia-tesla-a100"      ;;
+      "23"*  ) gpu_type="nvidia-h100"            ;; # NB: install does not begin with legacy image 2.0.68-debian10/cuda11.1
       "27B8" ) gpu_type="nvidia-l4"              ;; # NB: install does not complete with legacy image 2.0.68-debian10/cuda11.1
+      *      ) gpu_type="unrecognized"
     esac
 
     ACCELERATOR="type=${gpu_type},count=${gpu_count}"

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -15,7 +15,7 @@
 #
 # This script installs NVIDIA GPU drivers and collects GPU utilization metrics.
 
-set -euo pipefail
+set -xeuo pipefail
 
 function os_id()       { grep '^ID='               /etc/os-release | cut -d= -f2 | xargs ; }
 function os_version()  { grep '^VERSION_ID='       /etc/os-release | cut -d= -f2 | xargs ; }
@@ -293,6 +293,8 @@ function set_cudnn_version() {
   readonly CUDNN_VERSION
 }
 
+function is_cudnn8() { [[ "${CUDNN_VERSION%%.*}" == "8" ]] ; }
+function is_cudnn9() { [[ "${CUDNN_VERSION%%.*}" == "9" ]] ; }
 
 # Short name for urls
 if is_ubuntu22  ; then
@@ -622,13 +624,13 @@ function install_nvidia_nccl() {
     local local_tarball="${workdir}/${build_tarball}"
     local gcs_tarball="${pkg_bucket}/nvidia/nccl/${_shortname}/${build_tarball}"
 
-    if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
+    if [[ "$(hostname -s)" =~ ^test-gpu && "$(nproc)" < 32 ]] ; then
       # when running with fewer than 32 cores, yield to in-progress build
       sleep $(( ( RANDOM % 11 ) + 10 ))
-      local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building")"
+      local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
       if [[ "$?" == "0" ]] ; then
         local build_start_time build_start_epoch timeout_epoch
-        build_start_time="$(echo ${output} | awk -F': +' '/.reation.time/ {print $2}')"
+        build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
         build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
         timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
         while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
@@ -803,9 +805,10 @@ function install_pytorch() {
   if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
     # when running with fewer than 32 cores, yield to in-progress build
     sleep $(( ( RANDOM % 11 ) + 10 ))
-    if ${gsutil_stat_cmd} "${gcs_tarball}.building" ; then
+    local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+    if [[ "$?" == "0" ]] ; then
       local build_start_time build_start_epoch timeout_epoch
-      build_start_time="$(${gsutil_stat_cmd} "${gcs_tarball}.building" | awk -F': +' '/.reation.time/ {print $2}')"
+      build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
       build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
       timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
       while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
@@ -988,8 +991,7 @@ function add_repo_cuda() {
       | sudo tee "${sources_list_path}"
 
       for keyid in "0xae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80" "0xeb693b3035cd5710e231e123a4b469963bf863cc" ; do
-        curl ${curl_retry_args} "https://keyserver.ubuntu.com/pks/lookup?op=get&search=${keyid}" \
-        | gpg --import --no-default-keyring --keyring "${kr_path}"
+        gpg --keyserver keyserver.ubuntu.com --no-default-keyring --keyring "${kr_path}" --recv-keys "${keyid}"
       done
     else
       install_cuda_keyring_pkg # 11.7+, 12.0+
@@ -1029,9 +1031,10 @@ function build_driver_from_github() {
     if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
       # when running with fewer than 32 cores, yield to in-progress build
       sleep $(( ( RANDOM % 11 ) + 10 ))
-      if ${gsutil_stat_cmd} "${gcs_tarball}.building" ; then
+      local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+      if [[ "$?" == "0" ]] ; then
         local build_start_time build_start_epoch timeout_epoch
-        build_start_time="$(${gsutil_stat_cmd} "${gcs_tarball}.building" | awk -F': +' '/.reation.time/ {print $2}')"
+        build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
         build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
         timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
         while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
@@ -1180,10 +1183,10 @@ function install_nvidia_userspace_runfile() {
       if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
         # when running with fewer than 32 cores, yield to in-progress build
         sleep $(( ( RANDOM % 11 ) + 10 ))
-        local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building")"
-        if [[ $? == "0" ]] ; then
+        local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+        if [[ "$?" == "0" ]] ; then
           local build_start_time build_start_epoch timeout_epoch
-          build_start_time="$(echo ${output} | awk -F': +' '/.reation.time/ {print $2}')"
+          build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
           build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
           timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
           while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do

--- a/gpu/install_gpu_driver.sh
+++ b/gpu/install_gpu_driver.sh
@@ -1930,10 +1930,10 @@ function cache_fetched_package() {
   local local_fn="$3"
 
   if ${gsutil_stat_cmd} "${gcs_fn}" 2>&1 ; then
-    time ${gsutil_cmd} cp "${gcs_fn}" "${local_fn}"
+    execute_with_retries ${gsutil_cmd} cp "${gcs_fn}" "${local_fn}"
   else
     time ( curl ${curl_retry_args} "${src_url}" -o "${local_fn}" && \
-           ${gsutil_cmd} cp "${local_fn}" "${gcs_fn}" ; )
+           execute_with_retries ${gsutil_cmd} cp "${local_fn}" "${gcs_fn}" ; )
   fi
 }
 

--- a/gpu/test_gpu.py
+++ b/gpu/test_gpu.py
@@ -180,6 +180,9 @@ exit 1 unless $cert eq lc $kmod
   def test_install_gpu_without_agent(self, configuration, machine_suffixes,
                                      master_accelerator, worker_accelerator,
                                      driver_provider):
+    if self.getImageOs() == 'rocky' and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("disabling rocky9 builds due to out of date base dataproc image")
+
     metadata = "install-gpu-agent=false"
     if configuration == 'SINGLE' \
     and self.getImageOs() == 'rocky' \
@@ -210,6 +213,9 @@ exit 1 unless $cert eq lc $kmod
   def test_install_gpu_with_agent(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
                                   driver_provider):
+    if self.getImageOs() == 'rocky' and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("disabling rocky9 builds due to out of date base dataproc image")
+
     self.skipTest("No need to regularly test installing the agent on its own cluster ; this is exercised elsewhere")
 
     if configuration == 'KERBEROS' \
@@ -244,6 +250,8 @@ exit 1 unless $cert eq lc $kmod
   def test_install_gpu_cuda_nvidia(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
+    if self.getImageOs() == 'rocky' and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("disabling rocky9 builds due to out of date base dataproc image")
 
     if configuration == 'KERBEROS' \
     and self.getImageVersion() <= pkg_resources.parse_version("2.1"):
@@ -292,6 +300,9 @@ exit 1 unless $cert eq lc $kmod
   def test_install_gpu_with_mig(self, configuration, machine_suffixes,
                                   master_accelerator, worker_accelerator,
                                   driver_provider, cuda_version):
+    if self.getImageOs() == 'rocky' and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("disabling rocky9 builds due to out of date base dataproc image")
+
     # Operation [projects/.../regions/.../operations/...] failed:
     # Invalid value for field 'resource.machineType': \
     # 'https://www.googleapis.com/compute/v1/projects/.../zones/.../' \
@@ -333,6 +344,8 @@ exit 1 unless $cert eq lc $kmod
   )
   def test_gpu_allocation(self, configuration, master_accelerator,
                           worker_accelerator, driver_provider):
+    if self.getImageOs() == 'rocky' and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("disabling rocky9 builds due to out of date base dataproc image")
 
     if configuration == 'SINGLE' \
     and self.getImageOs() == 'rocky' \
@@ -366,6 +379,8 @@ exit 1 unless $cert eq lc $kmod
   def test_install_gpu_cuda_nvidia_with_spark_job(self, configuration, machine_suffixes,
                                    master_accelerator, worker_accelerator,
                                    cuda_version):
+    if self.getImageOs() == 'rocky' and self.getImageVersion() >= pkg_resources.parse_version("2.2"):
+      self.skipTest("disabling rocky9 builds due to out of date base dataproc image")
 
     if pkg_resources.parse_version(cuda_version) > pkg_resources.parse_version("12.4") \
     and ( ( self.getImageOs() == 'ubuntu' and self.getImageVersion() <= pkg_resources.parse_version("2.0") ) or \


### PR DESCRIPTION
* only pause for completion in github tests, not internal tests
* better timestamp extraction logic
* write directly to trust keychain with `gpg --recv-keys`
* fix string match code for GPU identification
* [disabling rocky9 builds due to out of date base dataproc image](https://github.com/GoogleCloudDataproc/initialization-actions/pull/1317/commits/b5b5c46e0e85403c31157d50b5fad7d9e4ed3fbe)