### PR TITLE
Set default task.resource.gpu.amount to a number much smaller than possible cores

### DIFF
--- a/spark-rapids/spark-rapids.sh
+++ b/spark-rapids/spark-rapids.sh
@@ -299,8 +299,12 @@ spark.executor.resource.gpu.discoveryScript=/usr/lib/spark/scripts/gpu/getGpusRe
 spark.dynamicAllocation.enabled=false
 spark.sql.autoBroadcastJoinThreshold=10m
 spark.sql.files.maxPartitionBytes=512m
-# please update this config according to your application
-spark.task.resource.gpu.amount=0.25
+# For Spark SQL, we want the scheduler to use the number of CPU cores as the
+# limiting resource (the number of tasks we can run in parallel is the number of cores).
+# We therefore set the per task GPU amount to a small number, telling the scheduler
+# to ignore the GPU when limiting parallel tasks, so we should see "number of cores" tasks
+# in parallel able to submit work to the GPU.
+spark.task.resource.gpu.amount=0.00001
 ###### END   : RAPIDS properties for Spark ${SPARK_VERSION} ######
 EOF
   else


### PR DESCRIPTION
We would like to set the default `spark.task.resource.gpu.amount` to a very small number, effectively removing this as part of the equation when Spark is deciding how many tasks can run in parallel in this executor. In the past, we have been setting this number to 1/# of cores, and we could do that here if we knew the number of cores that workers are assigned. That said, we think choosing a small number is simpler.

Note that this can still be overwritten by the user. Note also that the current default of 0.25 is not great, as we tend to run with 16 core executors.

@viadea @tgravescs @SurajAralihalli fyi