### PR TITLE
feat(gpu): Add robust proxy support for driver installation

### DIFF
--- a/gpu/README.md
+++ b/gpu/README.md
@@ -225,6 +225,18 @@ sometimes found in the "building from source" sections.
     modulus md5sum of the files referenced by both the private and
     public secret names.
 
+-   `http-proxy: <HOST>:<PORT>` - Optional. The address of an HTTP
+    proxy to use for internet egress. The script will configure `apt`,
+    `curl`, `gsutil`, `pip`, `java`, and `gpg` to use this proxy.
+
+-   `http-proxy-pem-uri: <GS_PATH>` - Optional. A `gs://` path to the
+    PEM-encoded certificate file used by the proxy specified in
+    `http-proxy`. This is needed if the proxy uses TLS and its
+    certificate is not already trusted by the cluster's default trust
+    store (e.g., if it's a self-signed certificate or signed by an
+    internal CA). The script will install this certificate into the
+    system and Java trust stores.
+
 #### Loading built kernel module
 
 For platforms which do not have pre-built binary kernel drivers, the

--- a/integration_tests/dataproc_test_case.py
+++ b/integration_tests/dataproc_test_case.py
@@ -199,10 +199,15 @@ class DataprocTestCase(parameterized.TestCase):
         bucket = "gs://dataproc-init-actions-test-{}".format(
             re.sub("[.:]", "", project.replace("google", "goog")))
 
-        ret_val, _, _ = self.run_command("gsutil ls -b {}".format(bucket))
-        # Create staging bucket if it does not exist
-        if ret_val != 0:
-            self.assert_command("gsutil mb {}".format(bucket))
+        # Check if the bucket exists by listing it.
+        ret_val, stdout, _ = self.run_command("gsutil ls -b {}".format(bucket))
+
+        # If gsutil ls -b succeeds and the bucket name is in the output, it exists.
+        if ret_val == 0 and bucket in stdout:
+            print(f"Bucket {bucket} already exists.")
+        else:
+            print(f"Bucket {bucket} does not exist or could not be verified, attempting to create.")
+            self.assert_command("gsutil mb -p {} -l {} {}".format(self.PROJECT, self.REGION, bucket))
 
         staging_dir = "{}/{}-{}".format(bucket, self.datetime_str(),
                                         self.random_str())


### PR DESCRIPTION
This PR significantly enhances support for installing GPU drivers
in environments requiring an HTTP/S proxy for internet access.
The `set_proxy` function now comprehensively configures APT, DNF,
GPG, conda and Java to use the proxy defined in instance metadata.

If a proxy certificate is provided via `http-proxy-pem-uri`, it's
added to the OS and Java trust stores, and tooling is configured
to use HTTPS for the proxy. This enables driver downloads and
package manager operations in locked-down VPCs where all egress
is via an SWP or other proxy.

Additional changes:

- `configure_dkms_certs` is now more idempotent, skipping key
   generation if files exist.

- Spark RAPIDS versions and repository URL aligned with
  `spark-rapids/spark-rapids.sh` to work towards a single
  GPU/RAPIDS installation script.

This work was validated in a development environment where all
internet egress was forced through a proxy.
