### PR TITLE
Fix(cloud-sql-proxy): Correct port specification for Cloud SQL proxy

### DIFF
--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -15,6 +15,7 @@ metadata on a given Cloud SQL instance.
 Specifically:
 * **MySQL 8.4 has updated its security model that were incompatible with the earlier version of this CloudSQL Proxy script.**
 
+
 To avoid connectivity issues, we highly recommend:
 * **Always testing your Cloud SQL Proxy configuration thoroughly** before adopting new Cloud SQL database versions or enabling advanced security features like Shared CA or Customer-managed CA.
 
@@ -84,7 +85,7 @@ shared hive metastore.
     a. Optionally add other instances, paired with distinct TCP ports for further I/O.
 
     ```bash
-        --metadata "additional-cloud-sql-instances=<PROJECT_ID>:<REGION>:<ANOTHER_INSTANCE_NAME>=tcp<PORT_#>[,...]"
+        --metadata "additional-cloud-sql-instances=<PROJECT_ID>:<REGION>:<ANOTHER_INSTANCE_NAME>=tcp:<PORT_NO>[,...]"
     ```
 
 1.  Submit pyspark_metastore_test.py to the cluster to validate the metatstore

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -374,6 +374,7 @@ function get_metastore_instance() {
       metastore_instance+="?port=${METASTORE_PROXY_PORT}"
     fi
   fi
+  metastore_instance="${metastore_instance//=tcp:/?port=}"
   echo "${metastore_instance}"
 }
 
@@ -393,6 +394,7 @@ function get_proxy_flags() {
     if [[ ${PROXY_VERSION} == "1" ]]; then
       proxy_instances_flags+=" -instances=${metastore_instance}"
     else
+      metastore_instance="${metastore_instance//=tcp:/?port=}"
       proxy_instances_flags+=" ${metastore_instance}"
     fi
   fi
@@ -402,7 +404,9 @@ function get_proxy_flags() {
     if [[ ${PROXY_VERSION} == "1" ]]; then
       proxy_instances_flags+=" -instances_metadata=instance/${ADDITIONAL_INSTANCES_KEY}"
     else
-      proxy_instances_flags+=" instances_metadata=instance/${ADDITIONAL_INSTANCES_KEY}"
+      updated_additional_instances="${ADDITIONAL_INSTANCES//,/ }"
+      updated_additional_instances="${updated_additional_instances//=tcp:/?port=}"
+      proxy_instances_flags+=" ${updated_additional_instances} "
     fi
   fi
 


### PR DESCRIPTION
Specifically, this commit:
- Modifies `cloud-sql-proxy.sh` to replace '=tcp:' with '?port=' in the instance connection strings for both the Hive metastore and any additional instances.
- Updates the `README.md` to reflect the correct metadata format for specifying additional instances.

This ensures compatibility with the updated Cloud SQL proxy and prevents connection failures.