### PR TITLE
Escape Perl variable $1 in repair_old_backports to prevent 'unbound v…

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -170,7 +170,7 @@ function repair_old_backports {
   for filename in "${matched_files[@]}"; do
     # Fetch from archive.debian.org for ${oldoldstable}-backports
     perl -pi -e "s{^(deb[^\s]*) https?://[^/]+/debian ${oldoldstable}-backports }
-                  {\$1 https://archive.debian.org/debian ${oldoldstable}-backports }g" "${filename}"
+                  {\\\$1 https://archive.debian.org/debian ${oldoldstable}-backports }g" "${filename}"
   done
 }
 


### PR DESCRIPTION
Title: Fix: Escape Perl variable $1 in cloud-sql-proxy.sh to prevent 'unbound variable' error
Description
This PR resolves a shell execution error that occurs during the provisioning of Dataproc clusters using the cloud-sql-proxy.sh initialization action when set -u (or set -o nounset) is active.

🐛 Issue
The repair_old_backports function in cloud-sql-proxy.sh uses a perl substitution command within double quotes:

```
perl -pi -e "s{...}{\$1 ...}g"
```

The shell (running with set -u) attempts to perform variable substitution on the Perl back-reference \$1 before passing the string to the perl interpreter. Since no positional parameter $1 is passed to the shell function, this causes the script to fail with the error:

```
/etc/google-dataproc/startup-scripts/dataproc-initialization-script-1: line 176: $1: unbound variable
```

✅ Solution
The fix involves triple-escaping the $1 within the double-quoted string:


```
# Corrected line 176:
perl -pi -e "s{...}{\\\$1 ...}g"
```

This ensures the string \$1 is passed literally to perl, allowing perl to correctly interpret it as a reference to the first captured group, thus preventing the shell from attempting to interpret it as an unset shell variable.