### PR TITLE
Fix GPG key import for Dataproc 3.0 (Debian 13)

### DIFF
--- a/kafka/kafka.sh
+++ b/kafka/kafka.sh
@@ -47,9 +47,10 @@ function recv_keys() {
   if [[ ${OS} == debian ]] && [[ $(echo "${DATAPROC_IMAGE_VERSION} >= 3.0" | bc -l) == 1 ]]; then
     retry_apt_command "apt-get update && apt-get install -y gnupg"
     export GNUPGHOME="$(mktemp -d)"
+    trap 'rm -rf "${GNUPGHOME}"' EXIT
     gpg --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C
+    mkdir -p /etc/apt/trusted.gpg.d
     gpg --export B7B3B788A8D3785C > /etc/apt/trusted.gpg.d/mysql-repo.gpg
-    rm -rf "$GNUPGHOME"
   else
     retry_apt_command "apt-get install -y gnupg2 && \
       apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C"


### PR DESCRIPTION
apt-key is deprecated and no longer available in Debian 13