### PR TITLE
fix(kafka): resolve broker registration failure due to JLine warnings

### DIFF
--- a/kafka/kafka.sh
+++ b/kafka/kafka.sh
@@ -98,7 +98,7 @@ function wait_for_zookeeper() {
 function wait_for_kafka() {
   for i in {1..20}; do
     local broker_list=$(get_broker_list || true)
-    if [[ "${broker_list}" == *" ${BROKER_ID},"* ]]; then
+    if echo "${broker_list}" | grep -q "${BROKER_ID}"; then
       return 0
     else
       echo "Kafka broker ${BROKER_ID} is not registered yet, retry ${i}..."


### PR DESCRIPTION
Problem:
During automated cluster creation, the wait_for_kafka function often fails to recognize a registered broker. This is caused by zookeeper-shell.sh emitting "Unable to create a system terminal" warnings which prepend noise to the $broker_list variable.

Root Cause:
The original strict glob match [[ "${broker_list}" == *" ${BROKER_ID},"* ]] fails because:

Terminal noise disrupts the string start.

The broker ID in the output is formatted as [10000, ...] (no leading space), while the script explicitly looks for a leading space.

Solution:
Replaced the strict pattern match with echo "${broker_list}" | grep -q "${BROKER_ID}". This substring search correctly identifies the broker ID regardless of terminal warnings or bracket formatting.

Validation:
Manually verified on a Dataproc Master node by sourcing the script and running wait_for_kafka with active JLine warnings present in the environment.