### PR TITLE
Integrated Google Cloud Secret Manager to fetch the Hive metastore password

### DIFF
--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -10,14 +10,15 @@ metadata on a given Cloud SQL instance.
 
 **⚠️ IMPORTANT COMPATIBILITY NOTICE ⚠️**
 
-**Cloud SQL Proxy V2 script has been upgraded to use the latest binary client that is compatible with MySQL 8.4 and some newer Cloud SQL features.**
+**The Cloud SQL Proxy script has been upgraded to use the V2 binary client by default, which is compatible with MySQL 8.4 and some newer Cloud SQL features.**
 
-Specifically:
-* **MySQL 8.4 has updated its security model that were incompatible with the earlier version of this CloudSQL Proxy script.**
-
+However, if you choose to use Cloud SQL Proxy V1 (see options below):
+*   **MySQL 8.4's updated security model is incompatible with Cloud SQL Proxy V1.**
+*   **Enabling "Shared CA"** or **"Customer-managed CA"** features for any Cloud SQL database (including older MySQL versions and PostgreSQL) will break connectivity with Cloud SQL Proxy V1.
 
 To avoid connectivity issues, we highly recommend:
-* **Always testing your Cloud SQL Proxy configuration thoroughly** before adopting new Cloud SQL database versions or enabling advanced security features like Shared CA or Customer-managed CA.
+*   **Using the default Cloud SQL Proxy V2.**
+*   **Always testing your Cloud SQL Proxy configuration thoroughly** before adopting new Cloud SQL database versions or enabling advanced security features, especially if not using the default V2 proxy.
 
 * The Dataproc team has updated the underlying Cloud SQL clients in Dataproc images to make use of Cloud SQL Proxy V2. The dataproc versions that are compatible with CloudSQL MySQL 8.4 are Dataproc versions 2.0.147, 2.1.96, 2.2.64 and 2.3.10 released on August 29, 2025.  See [Dataproc release notes](https://cloud.google.com/dataproc/docs/release-notes) for any new updates.
 

--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -12,6 +12,9 @@ metadata on a given Cloud SQL instance.
 
 **The Cloud SQL Proxy script has been upgraded to use the V2 binary client by default, which is compatible with MySQL 8.4 and some newer Cloud SQL features.**
 
+Specifically:
+* **MySQL 8.4 has an updated security model that was incompatible with the earlier version of this Cloud SQL Proxy script.**
+
 However, if you choose to use Cloud SQL Proxy V1 (see options below):
 *   **MySQL 8.4's updated security model is incompatible with Cloud SQL Proxy V1.**
 *   **Enabling "Shared CA"** or **"Customer-managed CA"** features for any Cloud SQL database (including older MySQL versions and PostgreSQL) will break connectivity with Cloud SQL Proxy V1.

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -263,6 +263,7 @@ readonly DB_ADMIN_PASSWORD
 # Database password used to access metastore.
 DB_HIVE_PASSWORD_URI="$(/usr/share/google/get_metadata_value attributes/db-hive-password-uri || echo '')"
 DB_HIVE_METASTORE_REUSE="$(/usr/share/google/get_metadata_value attributes/db-hive-metastore-reuse || echo '')"
+readonly DB_HIVE_METASTORE_REUSE
 
 readonly DB_HIVE_PASSWORD_URI
 if [[ -n "${DB_HIVE_PASSWORD_URI}" ]]; then

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -262,6 +262,8 @@ readonly DB_ADMIN_PASSWORD
 
 # Database password used to access metastore.
 DB_HIVE_PASSWORD_URI="$(/usr/share/google/get_metadata_value attributes/db-hive-password-uri || echo '')"
+DB_HIVE_METASTORE_REUSE="$(/usr/share/google/get_metadata_value attributes/db-hive-metastore-reuse || echo '')"
+
 readonly DB_HIVE_PASSWORD_URI
 if [[ -n "${DB_HIVE_PASSWORD_URI}" ]]; then
   # Decrypt password
@@ -522,18 +524,26 @@ function initialize_mysql_metastore_db() {
 
   # Check if metastore is initialized.
   if ! mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_HIVE_USER}" "${db_hive_password_param}" --get-server-public-key -e ''; then
-    mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-      "CREATE USER '${DB_HIVE_USER}' IDENTIFIED BY '${DB_HIVE_PASSWORD}';"
+    if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
+      mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
+        "CREATE USER '${DB_HIVE_USER}' IDENTIFIED BY '${DB_HIVE_PASSWORD}';"
+    else
+      log "Re-using exiting hive user account"
+    fi
   fi
+
   if ! mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_HIVE_USER}" "${db_hive_password_param}" --get-server-public-key -e "use ${METASTORE_DB}"; then
     # Initialize a Hive metastore DB
-    mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-      "CREATE DATABASE ${METASTORE_DB};
-       GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}';"
-    /usr/lib/hive/bin/schematool -dbType mysql -initSchema ||
-      err 'Failed to set mysql schema.'
+    if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
+      mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
+        "CREATE DATABASE ${METASTORE_DB};
+         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}';"
+      /usr/lib/hive/bin/schematool -dbType mysql -initSchema || err 'Failed to set mysql schema.'
+      log 'MYSQL DB initialized for Hive metastore'
+    else
+      log "Re-using exiting hive user account"
+    fi
   fi
-  log 'MYSQL DB initialized for Hive metastore'
 }
 
 function initialize_postgres_metastore_db() {

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -281,6 +281,19 @@ else
   if [[ "${db_hive_pwd}" == "None" ]]; then
     db_hive_pwd="hive-password"
   fi
+  hive_gsm_property=$(bdconfig get_property_value \
+    --configuration_file "/etc/hive/conf/hive-site.xml" \
+    --name "hadoop.security.credential.provider.path" 2>/dev/null)
+  if [[ -z "${hive_gsm_property}" ]]; then
+    hive_gsm_version=$(bdconfig get_property_value \
+      --configuration_file "/etc/hive/conf/hive-site.xml" \
+      --name "hadoop.security.credstore.google-secret-manager.secret-version" 2>/dev/null)
+    if [[ -z "${hive_gsm_version}" ]]; then
+      hive_gsm_version="latest"
+    fi
+    log "Fetching Hive password from Secret Manager (version: ${hive_gsm_version})..."
+    db_hive_pwd=$(gcloud secrets versions access "${hive_gsm_version}" --secret="javax-jdo-option-ConnectionPassword")
+  fi
   readonly DB_HIVE_PASSWORD=${db_hive_pwd}
 fi
 
@@ -506,6 +519,16 @@ EOF
       --configuration_file /etc/hive/conf/hive-site.xml \
       --source_configuration_file hive-template.xml \
       --clobber
+
+    hive_gsm_property=$(bdconfig get_property_value \
+      --configuration_file "/etc/hive/conf/hive-site.xml" \
+      --name "hadoop.security.credential.provider.path" 2>/dev/null)
+
+    if [[ -z "${hive_gsm_property}" ]]; then
+      log "Removing plaintext javax.jdo.option.ConnectionPassword from hive-site.xml..."
+      bdconfig remove_property --configuration_file "/etc/hive/conf/hive-site.xml" \
+      --name "javax.jdo.option.ConnectionPassword"
+    fi
   fi
 
   log 'Cloud SQL Proxy installation succeeded'
@@ -886,3 +909,4 @@ function main() {
 }
 
 main
+

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -377,7 +377,6 @@ function get_metastore_instance() {
       metastore_instance+="?port=${METASTORE_PROXY_PORT}"
     fi
   fi
-  metastore_instance="${metastore_instance//=tcp:/?port=}"
   echo "${metastore_instance}"
 }
 


### PR DESCRIPTION
Integrated Google Cloud Secret Manager to fetch the Hive metastore password. Added logic to clean up the plaintext password from hive-site.xml for improved security when GSM is used. Added informative logging to show when Secret Manager is being utilized.