### PR TITLE
Integrate Google Secret Manager for Hive password with logging

### DIFF
--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -10,14 +10,15 @@ metadata on a given Cloud SQL instance.
 
 **⚠️ IMPORTANT COMPATIBILITY NOTICE ⚠️**
 
-**Cloud SQL Proxy V2 script has been upgraded to use the latest binary client that is compatible with MySQL 8.4 and some newer Cloud SQL features.**
+**The Cloud SQL Proxy script has been upgraded to use the V2 binary client by default, which is compatible with MySQL 8.4 and some newer Cloud SQL features.**
 
-Specifically:
-* **MySQL 8.4 has updated its security model that were incompatible with the earlier version of this CloudSQL Proxy script.**
-
+However, if you choose to use Cloud SQL Proxy V1 (see options below):
+*   **MySQL 8.4's updated security model is incompatible with Cloud SQL Proxy V1.**
+*   **Enabling "Shared CA"** or **"Customer-managed CA"** features for any Cloud SQL database (including older MySQL versions and PostgreSQL) will break connectivity with Cloud SQL Proxy V1.
 
 To avoid connectivity issues, we highly recommend:
-* **Always testing your Cloud SQL Proxy configuration thoroughly** before adopting new Cloud SQL database versions or enabling advanced security features like Shared CA or Customer-managed CA.
+*   **Using the default Cloud SQL Proxy V2.**
+*   **Always testing your Cloud SQL Proxy configuration thoroughly** before adopting new Cloud SQL database versions or enabling advanced security features, especially if not using the default V2 proxy.
 
 * The Dataproc team has updated the underlying Cloud SQL clients in Dataproc images to make use of Cloud SQL Proxy V2. The dataproc versions that are compatible with CloudSQL MySQL 8.4 are Dataproc versions 2.0.147, 2.1.96, 2.2.64 and 2.3.10 released on August 29, 2025.  See [Dataproc release notes](https://cloud.google.com/dataproc/docs/release-notes) for any new updates.
 

--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -405,11 +405,11 @@ the `hive` user does not already exist in MySQL. Proceed as follows:
 
 As a more modern alternative to KMS, you can use [Secret Manager](https://cloud.google.com/secret-manager) to store and manage your Hive metastore passwords. The initialization action will automatically fetch the password from Secret Manager if the appropriate configuration is present in `hive-site.xml`.
 
-1.  **Create a Secret**: Create a secret named `javax-jdo-option-ConnectionPassword` in Secret Manager and add a version containing your Hive password.
+1.  **Create a Secret**: Create a secret named `javax-jdo-option-ConnectionPassword` in Secret Manager and add a version containing your Hive password. To create a Secret Manager see: https://docs.cloud.google.com/secret-manager/docs/create-secret-quickstart
+ 
+3.  **IAM Permissions**: Ensure the cluster's service account has the `roles/secretmanager.secretAccessor` role for the secret. To create a role see: https://docs.cloud.google.com/secret-manager/docs/manage-access-to-secrets
 
-2.  **IAM Permissions**: Ensure the cluster's service account has the `roles/secretmanager.secretAccessor` role for the secret.
-
-3.  **Create the Dataproc Cluster**: Specify the Secret Manager integration via cluster properties:
+4.  **Create the Dataproc Cluster**: Specify the Secret Manager integration via cluster properties:
 
     ```bash
     PROJECT_ID=<project_id>

--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -135,6 +135,9 @@ shared hive metastore.
     database in the SQL instance if they don't already exist. It does this by
     logging in as root with an empty password. You can reconfigure all of this
     in the script.
+*   If you are reusing an existing Cloud SQL instance that already has the
+    Hive user and database configured, you can set the `db-hive-metastore-reuse`
+    metadata key to `true` to skip these creation steps.
 
 ## Using this initialization action without configuring Hive metastore
 
@@ -397,3 +400,31 @@ the `hive` user does not already exist in MySQL. Proceed as follows:
     `/etc/hive/conf/hive-site.xml`. Therefore any user that can SSH on this
     cluster and has `sudo` access, and any user that can run jobs on this
     cluster, will be able to view the password in that file.
+
+## Protecting passwords with Secret Manager
+
+As a more modern alternative to KMS, you can use [Secret Manager](https://cloud.google.com/secret-manager) to store and manage your Hive metastore passwords. The initialization action will automatically fetch the password from Secret Manager if the appropriate configuration is present in `hive-site.xml`.
+
+1.  **Create a Secret**: Create a secret named `javax-jdo-option-ConnectionPassword` in Secret Manager and add a version containing your Hive password.
+
+2.  **IAM Permissions**: Ensure the cluster's service account has the `roles/secretmanager.secretAccessor` role for the secret.
+
+3.  **Create the Dataproc Cluster**: Specify the Secret Manager integration via cluster properties:
+
+    ```bash
+    PROJECT_ID=<project_id>
+    REGION=<region>
+    INSTANCE_NAME=<cloud_sql_instance_name>
+    CLUSTER_NAME=<cluster_name>
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --region ${REGION} \
+        --scopes cloud-platform \
+        --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/cloud-sql-proxy/cloud-sql-proxy.sh \
+        --metadata "hive-metastore-instance=${PROJECT_ID}:${REGION}:${INSTANCE_NAME}" \
+        --properties "hive:hadoop.security.credential.provider.path=gsm://projects/${PROJECT_ID}" \
+        --properties "hive:hadoop.security.credstore.google-secret-manager.secret-version=latest"
+    ```
+
+    *Note: The `hadoop.security.credential.provider.path` must be set to a value other than `None` (e.g., `gsm://projects/${PROJECT_ID}`) to enable the Secret Manager integration. You can specify a specific version instead of `latest` using the `hadoop.security.credstore.google-secret-manager.secret-version` property.*
+
+    When Secret Manager is used, the initialization action will automatically remove the plaintext `javax.jdo.option.ConnectionPassword` from the `/etc/hive/conf/hive-site.xml` file after the proxy is configured, providing an extra layer of security.

--- a/cloud-sql-proxy/README.md
+++ b/cloud-sql-proxy/README.md
@@ -12,6 +12,9 @@ metadata on a given Cloud SQL instance.
 
 **The Cloud SQL Proxy script has been upgraded to use the V2 binary client by default, which is compatible with MySQL 8.4 and some newer Cloud SQL features.**
 
+Specifically:
+* **MySQL 8.4 has an updated security model that was incompatible with the earlier version of this Cloud SQL Proxy script.**
+
 However, if you choose to use Cloud SQL Proxy V1 (see options below):
 *   **MySQL 8.4's updated security model is incompatible with Cloud SQL Proxy V1.**
 *   **Enabling "Shared CA"** or **"Customer-managed CA"** features for any Cloud SQL database (including older MySQL versions and PostgreSQL) will break connectivity with Cloud SQL Proxy V1.

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -281,6 +281,21 @@ else
   if [[ "${db_hive_pwd}" == "None" ]]; then
     db_hive_pwd="hive-password"
   fi
+  hive_gsm_property=$(bdconfig get_property_value \
+    --configuration_file "/etc/hive/conf/hive-site.xml" \
+    --name "hadoop.security.credential.provider.path" 2>/dev/null)
+  if [[ "${hive_gsm_property}" != "None" ]]; then
+    hive_gsm_version=$(bdconfig get_property_value \
+      --configuration_file "/etc/hive/conf/hive-site.xml" \
+      --name "hadoop.security.credstore.google-secret-manager.secret-version" 2>/dev/null)
+    if [[ "${hive_gsm_version}" == "None" ]]; then
+      hive_gsm_version="latest"
+    fi
+    log "Fetching Hive password from Secret Manager (version: ${hive_gsm_version})..."
+    if ! db_hive_pwd=$(gcloud secrets versions access "${hive_gsm_version}" --secret="javax-jdo-option-ConnectionPassword" 2>&1); then
+      err "Failed to fetch Hive password from Secret Manager. Ensure the secret 'javax-jdo-option-ConnectionPassword' exists and the service account has 'roles/secretmanager.secretAccessor' permission. Error: ${db_hive_pwd}"
+    fi
+  fi
   readonly DB_HIVE_PASSWORD=${db_hive_pwd}
 fi
 
@@ -506,6 +521,16 @@ EOF
       --configuration_file /etc/hive/conf/hive-site.xml \
       --source_configuration_file hive-template.xml \
       --clobber
+
+    hive_gsm_property=$(bdconfig get_property_value \
+      --configuration_file "/etc/hive/conf/hive-site.xml" \
+      --name "hadoop.security.credential.provider.path" 2>/dev/null)
+
+    if [[ "${hive_gsm_property}" != "None" ]]; then
+      log "Removing plaintext javax.jdo.option.ConnectionPassword from hive-site.xml..."
+      bdconfig remove_property --configuration_file "/etc/hive/conf/hive-site.xml" \
+        --name "javax.jdo.option.ConnectionPassword"
+    fi
   fi
 
   log 'Cloud SQL Proxy installation succeeded'
@@ -525,23 +550,31 @@ function initialize_mysql_metastore_db() {
   # Check if metastore is initialized.
   if ! mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_HIVE_USER}" "${db_hive_password_param}" --get-server-public-key -e ''; then
     if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
+      log "About to create hive user account."
       mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-        "CREATE USER '${DB_HIVE_USER}' IDENTIFIED BY '${DB_HIVE_PASSWORD}';"
+        "CREATE USER IF NOT EXISTS ${DB_HIVE_USER} IDENTIFIED BY '${DB_HIVE_PASSWORD}';
+         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO ${DB_HIVE_USER}@'%';
+         FLUSH PRIVILEGES;"
+      log "Hive user account created."
     else
-      log "Re-using exiting hive user account"
+      log "Re-using existing hive user account"
     fi
   fi
 
   if ! mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_HIVE_USER}" "${db_hive_password_param}" --get-server-public-key -e "use ${METASTORE_DB}"; then
     # Initialize a Hive metastore DB
     if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
+      log "About to create hive user account and ${METASTORE_DB} database."
       mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-        "CREATE DATABASE ${METASTORE_DB};
-         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}';"
+        "CREATE DATABASE IF NOT EXISTS ${METASTORE_DB};
+         CREATE USER IF NOT EXISTS ${DB_HIVE_USER}@'%' IDENTIFIED BY '${DB_HIVE_PASSWORD}';
+         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO ${DB_HIVE_USER}@'%';
+         FLUSH PRIVILEGES;"
+      log "Hive user account created"
       /usr/lib/hive/bin/schematool -dbType mysql -initSchema || err 'Failed to set mysql schema.'
       log 'MYSQL DB initialized for Hive metastore'
     else
-      log "Re-using exiting hive user account"
+      log "Re-using existing hive user account"
     fi
   fi
 }
@@ -886,3 +919,4 @@ function main() {
 }
 
 main
+

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -292,7 +292,7 @@ else
       hive_gsm_version="latest"
     fi
     log "Fetching Hive password from Secret Manager (version: ${hive_gsm_version})..."
-    if ! db_hive_pwd=$(gcloud secrets versions access "${hive_gsm_version}" --secret="javax-jdo-option-ConnectionPassword" 2>&1); then
+    if ! db_hive_pwd=$(gcloud secrets versions access "${hive_gsm_version}" --secret="javax-jdo-option-ConnectionPassword" 2>/dev/null); then
       err "Failed to fetch Hive password from Secret Manager. Ensure the secret 'javax-jdo-option-ConnectionPassword' exists and the service account has 'roles/secretmanager.secretAccessor' permission. Error: ${db_hive_pwd}"
     fi
   fi

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -263,6 +263,7 @@ readonly DB_ADMIN_PASSWORD
 # Database password used to access metastore.
 DB_HIVE_PASSWORD_URI="$(/usr/share/google/get_metadata_value attributes/db-hive-password-uri || echo '')"
 DB_HIVE_METASTORE_REUSE="$(/usr/share/google/get_metadata_value attributes/db-hive-metastore-reuse || echo '')"
+readonly DB_HIVE_METASTORE_REUSE
 
 readonly DB_HIVE_PASSWORD_URI
 if [[ -n "${DB_HIVE_PASSWORD_URI}" ]]; then

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -553,7 +553,7 @@ function initialize_mysql_metastore_db() {
       log "About to create hive user account."
       mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
         "CREATE USER IF NOT EXISTS '${DB_HIVE_USER}'@'%' IDENTIFIED BY '${DB_HIVE_PASSWORD}';
-         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO ${DB_HIVE_USER}@'%';
+         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}'@'%';
          FLUSH PRIVILEGES;"
       log "Hive user account created."
     else

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -568,7 +568,7 @@ function initialize_mysql_metastore_db() {
       mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
         "CREATE DATABASE IF NOT EXISTS ${METASTORE_DB};
          CREATE USER IF NOT EXISTS '${DB_HIVE_USER}'@'%' IDENTIFIED BY '${DB_HIVE_PASSWORD}';
-         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO ${DB_HIVE_USER}@'%';
+         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}'@'%';
          FLUSH PRIVILEGES;"
       log "Hive user account created"
       /usr/lib/hive/bin/schematool -dbType mysql -initSchema || err 'Failed to set mysql schema.'

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -552,7 +552,7 @@ function initialize_mysql_metastore_db() {
     if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
       log "About to create hive user account."
       mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-        "CREATE USER IF NOT EXISTS ${DB_HIVE_USER} IDENTIFIED BY '${DB_HIVE_PASSWORD}';
+        "CREATE USER IF NOT EXISTS '${DB_HIVE_USER}'@'%' IDENTIFIED BY '${DB_HIVE_PASSWORD}';
          GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO ${DB_HIVE_USER}@'%';
          FLUSH PRIVILEGES;"
       log "Hive user account created."

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -262,6 +262,8 @@ readonly DB_ADMIN_PASSWORD
 
 # Database password used to access metastore.
 DB_HIVE_PASSWORD_URI="$(/usr/share/google/get_metadata_value attributes/db-hive-password-uri || echo '')"
+DB_HIVE_METASTORE_REUSE="$(/usr/share/google/get_metadata_value attributes/db-hive-metastore-reuse || echo '')"
+
 readonly DB_HIVE_PASSWORD_URI
 if [[ -n "${DB_HIVE_PASSWORD_URI}" ]]; then
   # Decrypt password
@@ -522,18 +524,26 @@ function initialize_mysql_metastore_db() {
 
   # Check if metastore is initialized.
   if ! mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_HIVE_USER}" "${db_hive_password_param}" --get-server-public-key -e ''; then
-    mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-      "CREATE USER '${DB_HIVE_USER}' IDENTIFIED BY '${DB_HIVE_PASSWORD}';"
+    if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
+      mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
+        "CREATE USER '${DB_HIVE_USER}' IDENTIFIED BY '${DB_HIVE_PASSWORD}';"
+    else
+      log "Re-using exiting hive user account"
+    fi
   fi
+
   if ! mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_HIVE_USER}" "${db_hive_password_param}" --get-server-public-key -e "use ${METASTORE_DB}"; then
     # Initialize a Hive metastore DB
-    mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
-      "CREATE DATABASE ${METASTORE_DB};
-       GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}';"
-    /usr/lib/hive/bin/schematool -dbType mysql -initSchema ||
-      err 'Failed to set mysql schema.'
+    if [[ ! "${DB_HIVE_METASTORE_REUSE,,}" == "true" ]]; then
+      mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
+        "CREATE DATABASE ${METASTORE_DB};
+         GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${DB_HIVE_USER}';"
+      /usr/lib/hive/bin/schematool -dbType mysql -initSchema || err 'Failed to set mysql schema.'
+      log 'MYSQL DB initialized for Hive metastore'
+    else
+      log "Re-using exiting hive user account"
+    fi
   fi
-  log 'MYSQL DB initialized for Hive metastore'
 }
 
 function initialize_postgres_metastore_db() {

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -567,7 +567,7 @@ function initialize_mysql_metastore_db() {
       log "About to create hive user account and ${METASTORE_DB} database."
       mysql -h 127.0.0.1 -P "${METASTORE_PROXY_PORT}" -u "${DB_ADMIN_USER}" "${db_password_param}" --get-server-public-key -e \
         "CREATE DATABASE IF NOT EXISTS ${METASTORE_DB};
-         CREATE USER IF NOT EXISTS ${DB_HIVE_USER}@'%' IDENTIFIED BY '${DB_HIVE_PASSWORD}';
+         CREATE USER IF NOT EXISTS '${DB_HIVE_USER}'@'%' IDENTIFIED BY '${DB_HIVE_PASSWORD}';
          GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO ${DB_HIVE_USER}@'%';
          FLUSH PRIVILEGES;"
       log "Hive user account created"

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -377,7 +377,6 @@ function get_metastore_instance() {
       metastore_instance+="?port=${METASTORE_PROXY_PORT}"
     fi
   fi
-  metastore_instance="${metastore_instance//=tcp:/?port=}"
   echo "${metastore_instance}"
 }
 


### PR DESCRIPTION
Added a feature to allow the use of Google Secret Manager (GSM) for hive connectivity. In hive-site.xml, the property "javax.jdo.option.ConnectionPassword" will be removed since it will not be needed when GSM is used.