### PR TITLE
Add Dataproc 3.0 and Hive 4 compatibility to Hive lineage script

### DIFF
--- a/hive-lineage/hive-lineage.sh
+++ b/hive-lineage/hive-lineage.sh
@@ -48,8 +48,15 @@ function set_hive_lineage_conf() {
 
 function install_jars() {
   echo "Installing openlineage-hive hook"
-  gsutil cp -P "$INSTALLATION_SOURCE/hive-openlineage-hook-$HIVE_OL_HOOK_VERSION.jar" "$HIVE_LIB_DIR/hive-openlineage-hook.jar"
-}
+  gcloud storage cp "$INSTALLATION_SOURCE/hive-openlineage-hook-$HIVE_OL_HOOK_VERSION.jar" "$HIVE_LIB_DIR/hive-openlineage-hook.jar"
+  
+    echo "Copying GCP lineage transport jar into Hive lib folder for Dataproc 3.0 compatibility..."
+    if [[ -f "/usr/lib/spark/connector/transports-gcplineage.jar" ]]; then
+      cp "/usr/lib/spark/connector/transports-gcplineage.jar" "$HIVE_LIB_DIR/openlineage-gcp-transport.jar"
+    elif [[ -f "/usr/lib/spark/jars/transports-gcplineage.jar" ]]; then
+      cp "/usr/lib/spark/jars/transports-gcplineage.jar" "$HIVE_LIB_DIR/openlineage-gcp-transport.jar"
+    fi
+  }
 
 function restart_hive_server2_master() {
   # Safely get metadata without failing the script if the key is missing


### PR DESCRIPTION
On Dataproc 3.0 (Hive 4), OpenLineage requires the GCP lineage transport library (transports-gcplineage.jar) to be explicitly copied into Hive's library folder (/usr/lib/hive/lib/) so Hive can send lineage events to GCP Dataplex without throwing ClassNotFoundException.
  
  This change:
  1. Automatically copies Spark's transports-gcplineage.jar into Hive's library folder.
  2. Modernizes legacy "gsutil cp" calls to "gcloud storage cp".
  
  Verified end-to-end against Dataproc 3.0 Debian 13:
  http://sponge2/11f79ec0-b6d7-403e-8bc9-f7e923d70635